### PR TITLE
fix: branch-aware Jenkins pipeline, stable-only updater, and Docker CLI mount

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,14 @@ pipeline {
 
     stages {
 
-        // ─── CI: Tests ────────────────────────────────────────────────────
-        stage('Test .NET Backend') {
+        // ─── PRUEBAS UNITARIAS — dev y PRs hacia dev ─────────────────────
+        stage('Unit Test · .NET Backend') {
+            when {
+                anyOf {
+                    branch 'dev'
+                    changeRequest target: 'dev'
+                }
+            }
             steps {
                 sh '''
                     docker run --rm \
@@ -33,7 +39,13 @@ pipeline {
             }
         }
 
-        stage('Test Auth Service') {
+        stage('Unit Test · Auth Service') {
+            when {
+                anyOf {
+                    branch 'dev'
+                    changeRequest target: 'dev'
+                }
+            }
             steps {
                 sh '''
                     docker run --rm \
@@ -45,39 +57,110 @@ pipeline {
             }
         }
 
-        // ─── Promoción dev → qa ───────────────────────────────────────────
-        stage('Promote dev → qa') {
+        // ─── AUTO-PR dev → qa (solo tras merge/commit a dev, nunca en PRs) ─
+        stage('Auto PR: dev → qa') {
             when { branch 'dev' }
             steps {
                 withCredentials([string(credentialsId: 'github-token', variable: 'GH_TOKEN')]) {
                     sh '''
-                        git config user.email "jenkins@tucolmadord.com"
-                        git config user.name  "Jenkins CI"
-                        git push "https://x-access-token:${GH_TOKEN}@${GH_REMOTE#https://}" \
-                            HEAD:refs/heads/qa --force
-                        echo "✅ Promovido dev → qa"
+                        PR_EXISTS=$(curl -sf \
+                            "https://api.github.com/repos/${GH_REPO}/pulls?head=odimsom:dev&base=qa&state=open" \
+                            -H "Authorization: token ${GH_TOKEN}" \
+                            | grep -c '"number"' || true)
+
+                        if [ "${PR_EXISTS:-0}" -gt 0 ]; then
+                            echo "ℹ️  Ya existe un PR abierto dev → qa"
+                        else
+                            curl -sf -X POST \
+                                "https://api.github.com/repos/${GH_REPO}/pulls" \
+                                -H "Authorization: token ${GH_TOKEN}" \
+                                -H "Content-Type: application/json" \
+                                -d "{
+                                    \\"title\\": \\"[Auto] Promote dev → qa · Build #${BUILD_NUMBER}\\",
+                                    \\"head\\": \\"dev\\",
+                                    \\"base\\": \\"qa\\",
+                                    \\"body\\": \\"PR automático: pruebas unitarias pasaron (build #${BUILD_NUMBER}).\\\\n\\\\nPendiente: pruebas de integración deben pasar en este PR antes del merge.\\"
+                                }" > /dev/null
+                            echo "✅ PR creado: dev → qa"
+                        fi
                     '''
                 }
             }
         }
 
-        // ─── Promoción qa → main ──────────────────────────────────────────
-        stage('Promote qa → main') {
+        // ─── PRUEBAS DE INTEGRACIÓN — qa y PRs hacia qa ──────────────────
+        stage('Integration Test · .NET Backend') {
+            when {
+                anyOf {
+                    branch 'qa'
+                    changeRequest target: 'qa'
+                }
+            }
+            steps {
+                sh '''
+                    docker run --rm \
+                        -v "${WORKSPACE}/backend:/workspace" \
+                        -w /workspace \
+                        mcr.microsoft.com/dotnet/sdk:10.0-preview \
+                        bash -c "
+                            dotnet restore TuColmadoRD.slnx &&
+                            dotnet build TuColmadoRD.slnx -c Release --no-restore &&
+                            dotnet test TuColmadoRD.slnx -c Release --no-build --verbosity normal
+                        "
+                '''
+            }
+        }
+
+        stage('Integration Test · Auth Service') {
+            when {
+                anyOf {
+                    branch 'qa'
+                    changeRequest target: 'qa'
+                }
+            }
+            steps {
+                sh '''
+                    docker run --rm \
+                        -v "${WORKSPACE}/auth:/workspace" \
+                        -w /workspace \
+                        node:22-alpine \
+                        sh -c "npm install -g pnpm && pnpm install --frozen-lockfile && pnpm test"
+                '''
+            }
+        }
+
+        // ─── AUTO-PR qa → main (solo tras merge/commit a qa, nunca en PRs) ─
+        stage('Auto PR: qa → main') {
             when { branch 'qa' }
             steps {
                 withCredentials([string(credentialsId: 'github-token', variable: 'GH_TOKEN')]) {
                     sh '''
-                        git config user.email "jenkins@tucolmadord.com"
-                        git config user.name  "Jenkins CI"
-                        git push "https://x-access-token:${GH_TOKEN}@${GH_REMOTE#https://}" \
-                            HEAD:refs/heads/main --force
-                        echo "✅ Promovido qa → main"
+                        PR_EXISTS=$(curl -sf \
+                            "https://api.github.com/repos/${GH_REPO}/pulls?head=odimsom:qa&base=main&state=open" \
+                            -H "Authorization: token ${GH_TOKEN}" \
+                            | grep -c '"number"' || true)
+
+                        if [ "${PR_EXISTS:-0}" -gt 0 ]; then
+                            echo "ℹ️  Ya existe un PR abierto qa → main"
+                        else
+                            curl -sf -X POST \
+                                "https://api.github.com/repos/${GH_REPO}/pulls" \
+                                -H "Authorization: token ${GH_TOKEN}" \
+                                -H "Content-Type: application/json" \
+                                -d "{
+                                    \\"title\\": \\"[Auto] Promote qa → main · Build #${BUILD_NUMBER}\\",
+                                    \\"head\\": \\"qa\\",
+                                    \\"base\\": \\"main\\",
+                                    \\"body\\": \\"PR automático: pruebas de integración pasaron en qa (build #${BUILD_NUMBER}).\\\\n\\\\nMerge para desplegar a producción.\\"
+                                }" > /dev/null
+                            echo "✅ PR creado: qa → main"
+                        fi
                     '''
                 }
             }
         }
 
-        // ─── CD: Deploy a producción ──────────────────────────────────────
+        // ─── DEPLOY A PRODUCCIÓN — solo en main ───────────────────────────
         stage('Deploy to Production') {
             when { branch 'main' }
             steps {
@@ -99,16 +182,12 @@ pipeline {
             }
         }
 
-        // ─── Release en GitHub ────────────────────────────────────────────
-        // Crea el tag vX.Y.Z y la release en GitHub.
-        // GitHub Actions (cd-deploy.yml) luego adjunta el instalador .exe
-        // a esta misma release usando allow_updates: true.
+        // ─── RELEASE EN GITHUB — solo en main ─────────────────────────────
         stage('Create GitHub Release') {
             when { branch 'main' }
             steps {
                 withCredentials([string(credentialsId: 'github-token', variable: 'GH_TOKEN')]) {
                     sh '''
-                        # Leer versión desde package.json (sin dependencias externas)
                         VERSION=$(grep -m1 '"version"' frontend/package.json \
                                   | sed 's/.*"version": *"\\([^"]*\\)".*/\\1/')
                         TAG="v${VERSION}"
@@ -118,7 +197,6 @@ pipeline {
 
                         echo "📦 Creando release ${TAG} (build #${BUILD})..."
 
-                        # Crear o reusar tag en GitHub
                         git config user.email "jenkins@tucolmadord.com"
                         git config user.name  "Jenkins CI"
 
@@ -126,14 +204,12 @@ pipeline {
                         git tag -f "$TAG" -m "Release ${TAG}"
                         git push "$REMOTE" "$TAG" --force
 
-                        # Crear release via API (si ya existe, la actualiza)
                         BODY="### Deploy #${BUILD} — Producción\\n\\n\
 **Versión:** \\`${TAG}\\`  \\n\
 **Commit:** [\\`${SHORT}\\`](https://github.com/${GH_REPO}/commit/${COMMIT})  \\n\
 **Rama:** main  \\n\\n\
 > Instalador Windows adjuntado automáticamente por GitHub Actions."
 
-                        # Intentar crear; si falla (ya existe), buscar y actualizar
                         CREATE_RESP=$(curl -s -w "\\n%{http_code}" \
                             -X POST \
                             "https://api.github.com/repos/${GH_REPO}/releases" \
@@ -164,7 +240,7 @@ pipeline {
                                 }" > /dev/null
                         fi
 
-                        echo "✅ Release ${TAG} lista en GitHub"
+                        echo "✅ Release ${TAG} lista"
                         echo "   https://github.com/${GH_REPO}/releases/tag/${TAG}"
                     '''
                 }

--- a/backend/src/Presentations/TuColmadoRD.Desktop/UpdateService.cs
+++ b/backend/src/Presentations/TuColmadoRD.Desktop/UpdateService.cs
@@ -20,10 +20,9 @@ internal static class UpdateService
         if (localResolved != null)
         {
             var currentInstalledVersion = GetCurrentVersion();
-            var isTestTag = localResolved.Tag.Contains("-test", StringComparison.OrdinalIgnoreCase);
             var hasNewerVersion = localResolved.Version > currentInstalledVersion;
 
-            if (isTestTag || hasNewerVersion)
+            if (hasNewerVersion)
             {
                 return new UpdateCheckResult
                 {
@@ -74,7 +73,9 @@ internal static class UpdateService
         }
 
         var latest = releases
-            .Where(r => !string.IsNullOrWhiteSpace(r.TagName))
+            .Where(r => !string.IsNullOrWhiteSpace(r.TagName)
+                     && !r.Prerelease
+                     && !r.TagName!.Contains("-test", StringComparison.OrdinalIgnoreCase))
             .Select(r => new
             {
                 Release = r,
@@ -89,10 +90,8 @@ internal static class UpdateService
             return UpdateCheckResult.NoUpdate;
         }
 
-        var latestTag = latest.Release.TagName ?? string.Empty;
-        var isTestRelease = latestTag.Contains("-test", StringComparison.OrdinalIgnoreCase);
         var currentVersion = GetCurrentVersion();
-        if (!isTestRelease && latest.Version! <= currentVersion)
+        if (latest.Version! <= currentVersion)
         {
             return UpdateCheckResult.NoUpdate;
         }
@@ -251,6 +250,7 @@ internal static class UpdateService
     private sealed class GitHubRelease
     {
         public string? TagName { get; set; }
+        public bool Prerelease { get; set; }
         public List<GitHubAsset> Assets { get; set; } = new();
     }
 

--- a/docker-compose.jenkins.yml
+++ b/docker-compose.jenkins.yml
@@ -15,6 +15,7 @@ services:
     volumes:
       - jenkins_home:/var/jenkins_home
       - /var/run/docker.sock:/var/run/docker.sock
+      - /usr/bin/docker:/usr/bin/docker
     networks:
       - traefik-net
     labels:

--- a/frontend/web-admin/src/app/core/services/download.service.ts
+++ b/frontend/web-admin/src/app/core/services/download.service.ts
@@ -34,52 +34,36 @@ export class DownloadService {
     'https://api.github.com/repos/synsetsolutions/TuColmadoRD-Monorepo/releases'
   ];
 
-  getLatestTestRelease(): Observable<DownloadInfo | null> {
+  getLatestRelease(): Observable<DownloadInfo | null> {
     return this.http.get<GithubRelease[]>(this.releasesUrls[0]).pipe(
-      map(releases => {
-        // Filtrar solo pre-releases con tag -test
-        const testReleases = releases.filter(r => 
-          r.prerelease && r.tag_name.includes('-test')
-        );
-        
-        if (!testReleases.length) return this.getFallbackDownloadInfo();
-        
-        // Tomar el más reciente (GitHub los devuelve ordenados por fecha descendente)
-        const latest = testReleases[0];
-        const asset = latest.assets.find(a => a.name.endsWith('.exe'));
-        
-        if (!asset) return this.getFallbackDownloadInfo();
-        
-        return {
-          version: latest.tag_name,
-          downloadUrl: asset.browser_download_url,
-          fileSize: this.formatBytes(asset.size),
-          publishedAt: latest.published_at
-        };
-      }),
+      map(releases => this.resolveStableRelease(releases)),
       catchError(() => this.http.get<GithubRelease[]>(this.releasesUrls[1]).pipe(
-        map(releases => {
-          const testReleases = releases.filter(r =>
-            r.prerelease && r.tag_name.includes('-test')
-          );
-
-          if (!testReleases.length) return this.getFallbackDownloadInfo();
-
-          const latest = testReleases[0];
-          const asset = latest.assets.find(a => a.name.endsWith('.exe'));
-
-          if (!asset) return this.getFallbackDownloadInfo();
-
-          return {
-            version: latest.tag_name,
-            downloadUrl: asset.browser_download_url,
-            fileSize: this.formatBytes(asset.size),
-            publishedAt: latest.published_at
-          };
-        }),
+        map(releases => this.resolveStableRelease(releases)),
         catchError(() => of(this.getFallbackDownloadInfo()))
       ))
     );
+  }
+
+  private resolveStableRelease(releases: GithubRelease[]): DownloadInfo | null {
+    // Solo releases estables: sin prerelease y sin sufijo -test
+    const stable = releases.filter(r =>
+      !r.prerelease && !r.tag_name.includes('-test')
+    );
+
+    if (!stable.length) return this.getFallbackDownloadInfo();
+
+    // GitHub los devuelve ordenados por fecha descendente
+    const latest = stable[0];
+    const asset = latest.assets.find(a => a.name.endsWith('.exe'));
+
+    if (!asset) return this.getFallbackDownloadInfo();
+
+    return {
+      version: latest.tag_name,
+      downloadUrl: asset.browser_download_url,
+      fileSize: this.formatBytes(asset.size),
+      publishedAt: latest.published_at
+    };
   }
 
   private getFallbackDownloadInfo(): DownloadInfo | null {

--- a/frontend/web-admin/src/app/layouts/portal-layout/portal-layout.spec.ts
+++ b/frontend/web-admin/src/app/layouts/portal-layout/portal-layout.spec.ts
@@ -15,7 +15,7 @@ describe('PortalLayout', () => {
 
   beforeEach(async () => {
     const authMock = { currentUser: () => null, logout: vi.fn(), isLicenseExpired: () => false };
-    const downloadMock = { getLatestTestRelease: vi.fn().mockReturnValue(of(null)) };
+    const downloadMock = { getLatestRelease: vi.fn().mockReturnValue(of(null)) };
     const saleMock = { getCurrentShift: vi.fn().mockReturnValue(throwError(() => new Error('no shift'))) };
 
     await TestBed.configureTestingModule({

--- a/frontend/web-admin/src/app/layouts/portal-layout/portal-layout.ts
+++ b/frontend/web-admin/src/app/layouts/portal-layout/portal-layout.ts
@@ -51,7 +51,7 @@ export class PortalLayout implements OnInit, OnDestroy {
   }
 
   loadDownloadInfo(): void {
-    this.downloads.getLatestTestRelease()
+    this.downloads.getLatestRelease()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(info => this.downloadInfo.set(info));
   }


### PR DESCRIPTION
## Summary

- **Jenkinsfile**: cada stage ahora tiene condición `when` — unit tests solo en `dev`/PRs-a-dev, integration tests solo en `qa`/PRs-a-qa, deploy/release solo en `main`. Promoción ahora crea PRs automáticos vía GitHub API en vez de `git push --force`.
- **docker-compose.jenkins.yml**: monta `/usr/bin/docker` del host → Docker CLI disponible permanentemente en Jenkins (fix del error `docker: not found`).
- **DownloadService** (Angular): `getLatestTestRelease` → `getLatestRelease`, filtra solo releases estables (sin `prerelease`, sin `-test`).
- **UpdateService.cs** (Desktop): agrega campo `Prerelease` al modelo, filtra prereleases en fallback de GitHub, corrige condición errónea en path de API local.

## Test plan

- [ ] Jenkins corre unit tests solo al hacer push/PR hacia `dev`
- [ ] Jenkins crea PR automático `dev → qa` tras pasar unit tests en `dev`
- [ ] Jenkins corre integration tests solo al hacer push/PR hacia `qa`
- [ ] Jenkins crea PR automático `qa → main` tras pasar integration tests en `qa`
- [ ] Jenkins deploy corre solo en `main`
- [ ] Docker ya no da `not found` en el agente Jenkins
- [ ] Banner de descarga en web-admin no muestra versiones `-test`
- [ ] Desktop app no propone actualizar a versiones prerelease