### PR TITLE
fix(responsive+delivery): mobile sidebar drawer, POS tab UI, delivery map nav

### DIFF
--- a/frontend/web-admin/e2e/responsive-audit.spec.ts
+++ b/frontend/web-admin/e2e/responsive-audit.spec.ts
@@ -1,0 +1,105 @@
+import { test } from '@playwright/test';
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+
+const PAGES = [
+  { name: 'dashboard',    path: '/portal/dashboard' },
+  { name: 'customers',   path: '/portal/customers' },
+  { name: 'inventory',   path: '/portal/inventory' },
+  { name: 'expenses',    path: '/portal/expenses' },
+  { name: 'deliveries',  path: '/portal/deliveries' },
+  { name: 'subscription', path: '/portal/subscription' },
+  { name: 'pos',         path: '/pos' },
+];
+
+// Structurally-valid JWT — Angular guard only checks payload.exp, never the signature.
+const FAKE_TOKEN =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' +
+  '.eyJzdWIiOiJ0ZXN0LXVzZXItaWQiLCJ0ZW5hbnRfaWQiOiJhMWIyYzNkNC1lNWY2LTc4OTAtYWJjZC1lZjEyMzQ1Njc4OTAiLCJ0ZXJtaW5hbF9pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMCIsInJvbGUiOiJvd25lciIsImVtYWlsIjoidGVzdEB0dWNvbG1hZG9yZC5jb20iLCJzdWJzY3JpcHRpb25fc3RhdHVzIjoiYWN0aXZlIiwiaWF0IjoxNzc4OTUxODg1LCJleHAiOjE3ODE1NDM4ODV9' +
+  '.ZmFrZXNpZ25hdHVyZV9mb3JfY2xpZW50X3NpZGVfb25seQ';
+
+const FAKE_USER = JSON.stringify({
+  id: 'test-user-id',
+  email: 'test@tucolmadord.com',
+  firstName: 'Test',
+  lastName: 'User',
+  role: 'owner',
+  tenantId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  subscriptionStatus: 'active',
+});
+
+const TENANT_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+// Stub API responses so the auth interceptor never sees a 401.
+// Pages will render their layout with empty / skeleton data.
+const API_STUBS: Record<string, object> = {
+  // dashboard
+  'dashboard':         { data: null },
+  'shift':             { id: null, status: 'open', startTime: new Date().toISOString() },
+  'stats':             { revenue: 0, criticalStock: 0, pendingDebts: 0, expenses: 0, shiftDuration: '0m' },
+  'transactions':      { items: [], total: 0, page: 1, pageSize: 10 },
+  // customers
+  'customers':         { items: [], total: 0, page: 1, pageSize: 20 },
+  // inventory
+  'products':          { items: [], total: 0, page: 1, pageSize: 20 },
+  'categories':        { items: [] },
+  // expenses
+  'expenses':          { items: [], total: 0, page: 1, pageSize: 20 },
+  // deliveries
+  'deliveries':        { items: [], total: 0, page: 1, pageSize: 20 },
+  // subscription / license
+  'license':           { status: 'active', plan: 'pro', renewsAt: '2026-12-31' },
+  'subscription':      { status: 'active', plan: 'pro', renewsAt: '2026-12-31' },
+  // POS
+  'catalog':           { items: [], total: 0 },
+};
+
+test.describe('Mobile Responsive Audit — iPhone 14 (390×844)', () => {
+  test.use({ viewport: MOBILE_VIEWPORT });
+
+  test('screenshot all pages at mobile viewport', async ({ page }) => {
+    // 1. Intercept ALL requests to the API gateway and return stub 200 responses.
+    await page.route('**/gateway/**', async (route) => {
+      const url = route.request().url();
+      // Find the matching stub key
+      const stub = Object.entries(API_STUBS).find(([key]) => url.includes(key));
+      if (stub) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(stub[1]),
+        });
+      } else {
+        // For unmatched endpoints return an empty 200
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: '{}',
+        });
+      }
+    });
+
+    // 2. Inject auth into localStorage BEFORE Angular boots.
+    await page.addInitScript(
+      ({ token, user, tenantId }) => {
+        localStorage.setItem('tc_token', token);
+        localStorage.setItem('tc_user', user);
+        localStorage.setItem('tc_tenant', tenantId);
+      },
+      { token: FAKE_TOKEN, user: FAKE_USER, tenantId: TENANT_ID }
+    );
+
+    // 3. Screenshot each page.
+    for (const { name, path } of PAGES) {
+      await page.goto(path);
+      // Wait for Angular routing + data fetch stubs to settle
+      await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {});
+      await page.waitForTimeout(2500);
+
+      await page.screenshot({
+        path: `e2e/results/mobile-${name}.png`,
+        fullPage: true,
+      });
+    }
+  });
+});

--- a/frontend/web-admin/src/app/layouts/delivery-layout/delivery-layout.html
+++ b/frontend/web-admin/src/app/layouts/delivery-layout/delivery-layout.html
@@ -99,6 +99,25 @@
             </div>
           </div>
 
+          <!-- Navigation (InTransit only) -->
+          @if (order.status === 'InTransit') {
+            <div class="px-4 py-2.5 border-t border-white/[0.04] space-y-2">
+              <p class="text-[0.6rem] font-bold text-slate-500 uppercase tracking-wider">Cómo llegar</p>
+              <div class="flex gap-2">
+                <a [href]="mapsUrl(order)" target="_blank"
+                  class="flex-1 flex items-center justify-center gap-1.5 py-2.5 rounded-xl bg-blue-600/15 border border-blue-500/25 text-blue-400 hover:bg-blue-600/25 text-xs font-bold transition-colors">
+                  <span class="icon-[ic--baseline-map] text-sm"></span>
+                  Google Maps
+                </a>
+                <a [href]="wazeUrl(order)" target="_blank"
+                  class="flex-1 flex items-center justify-center gap-1.5 py-2.5 rounded-xl bg-amber-500/10 border border-amber-500/25 text-amber-400 hover:bg-amber-500/20 text-xs font-bold transition-colors">
+                  <span class="icon-[ic--baseline-navigation] text-sm"></span>
+                  Waze
+                </a>
+              </div>
+            </div>
+          }
+
           <!-- Actions -->
           <div class="px-4 py-3 flex gap-2">
             @if (order.status === 'Pending') {
@@ -111,7 +130,7 @@
               <button (click)="openCompleteModal(order)" [disabled]="actingOn() === order.id"
                 class="flex-1 py-2.5 rounded-xl bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white text-sm font-bold transition-colors flex items-center justify-center gap-1.5">
                 <span class="icon-[ic--baseline-check-circle]"></span>
-                Completar entrega
+                Confirmar entrega
               </button>
             }
           </div>

--- a/frontend/web-admin/src/app/layouts/delivery-layout/delivery-layout.ts
+++ b/frontend/web-admin/src/app/layouts/delivery-layout/delivery-layout.ts
@@ -208,6 +208,20 @@ export class DeliveryLayout implements OnInit, OnDestroy, AfterViewChecked {
     });
   }
 
+  mapsUrl(order: DeliveryOrderDto): string {
+    if (order.latitude && order.longitude)
+      return `https://www.google.com/maps/dir/?api=1&destination=${order.latitude},${order.longitude}`;
+    const addr = encodeURIComponent(`${order.street}${order.houseNumber ? ' #' + order.houseNumber : ''}, ${order.sector}, ${order.province}, República Dominicana`);
+    return `https://www.google.com/maps/dir/?api=1&destination=${addr}`;
+  }
+
+  wazeUrl(order: DeliveryOrderDto): string {
+    if (order.latitude && order.longitude)
+      return `https://waze.com/ul?ll=${order.latitude},${order.longitude}&navigate=yes`;
+    const addr = encodeURIComponent(`${order.street}, ${order.sector}, ${order.province}, República Dominicana`);
+    return `https://waze.com/ul?q=${addr}&navigate=yes`;
+  }
+
   logout(): void {
     this.auth.logout();
     this.router.navigate(['/auth/login']);

--- a/frontend/web-admin/src/app/layouts/portal-layout/portal-layout.component.html
+++ b/frontend/web-admin/src/app/layouts/portal-layout/portal-layout.component.html
@@ -1,5 +1,10 @@
 <div class="min-h-screen bg-[#060d1a] relative overflow-hidden flex transition-all duration-500">
 
+  <!-- Mobile sidebar backdrop -->
+  @if (isMobileSidebarOpen()) {
+    <div class="fixed inset-0 z-30 bg-black/70 lg:hidden" (click)="closeMobileSidebar()"></div>
+  }
+
   <!-- Overlay de licencia vencida -->
   @if (isLicenseExpired() && !isOnSubscriptionPage()) {
     <div class="fixed inset-0 z-50 flex items-center justify-center">
@@ -32,10 +37,16 @@
   <div class="absolute bottom-0 right-0 w-[400px] h-[400px] bg-blue-900/5 rounded-full blur-[120px] pointer-events-none z-0"></div>
 
   <!-- ===================== SIDEBAR ===================== -->
+  <!-- Mobile: fixed off-canvas drawer (z-40, above backdrop z-30).
+       Desktop (lg+): sticky in-flow sidebar with collapse toggle. -->
   <aside
     [class.w-72]="!isSidebarCollapsed()"
     [class.w-[72px]]="isSidebarCollapsed()"
-    class="bg-[#080f1e]/98 backdrop-blur-3xl border-r border-white/[0.06] flex flex-col h-screen sticky top-0 z-30 transition-all duration-300 ease-in-out"
+    [class.-translate-x-full]="!isMobileSidebarOpen()"
+    [class.translate-x-0]="isMobileSidebarOpen()"
+    class="fixed top-0 left-0 h-full z-40 lg:sticky lg:top-0 lg:z-30 lg:h-screen lg:translate-x-0 w-72
+           bg-[#080f1e]/98 backdrop-blur-3xl border-r border-white/[0.06] flex flex-col
+           transition-transform duration-300 ease-in-out"
   >
     <!-- Logo -->
     <div class="px-5 py-5 border-b border-white/[0.06] flex items-center" [class.justify-center]="isSidebarCollapsed()">
@@ -208,10 +219,14 @@
   <div class="flex-grow flex flex-col min-w-0 relative h-screen overflow-hidden">
 
     <!-- Header -->
-    <header class="h-14 border-b border-white/[0.06] flex items-center justify-between px-6 bg-[#080f1e]/80 backdrop-blur-md sticky top-0 z-20">
+    <header class="h-14 border-b border-white/[0.06] flex items-center justify-between px-3 sm:px-6 bg-[#080f1e]/80 backdrop-blur-md sticky top-0 z-20">
 
-      <!-- Left: connection + context -->
-      <div class="flex items-center gap-4">
+      <!-- Left: hamburger (mobile) + connection + context -->
+      <div class="flex items-center gap-2 sm:gap-4">
+        <!-- Hamburger — only visible on mobile -->
+        <button (click)="toggleMobileSidebar()" class="lg:hidden p-2 rounded-lg text-slate-400 hover:text-white hover:bg-white/[0.06] transition-colors">
+          <span class="icon-[ic--baseline-menu] text-xl"></span>
+        </button>
         <!-- Online/Offline indicator -->
         <div class="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-white/[0.04] border border-white/[0.06]">
           <span class="relative flex h-1.5 w-1.5">
@@ -227,7 +242,7 @@
             [class.text-red-400]="connectionStatus() === 'offline'">{{ connectionStatus() }}</span>
         </div>
 
-        <div class="h-3.5 w-px bg-white/10"></div>
+        <div class="hidden sm:block h-3.5 w-px bg-white/10"></div>
 
         <!-- Active shift indicator -->
         @if (activeShift()) {
@@ -247,9 +262,9 @@
       <!-- Right: actions -->
       <div class="flex items-center gap-3">
         <!-- Nueva Venta CTA -->
-        <a routerLink="/pos" class="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-[0.65rem] font-black uppercase tracking-widest transition-all shadow-lg shadow-blue-600/20 flex items-center gap-1.5">
+        <a routerLink="/pos" class="px-3 sm:px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-[0.65rem] font-black uppercase tracking-widest transition-all shadow-lg shadow-blue-600/20 flex items-center gap-1.5">
           <span class="icon-[ic--baseline-point-of-sale] text-sm"></span>
-          Nueva Venta
+          <span class="hidden sm:inline">Nueva Venta</span>
         </a>
       </div>
     </header>
@@ -258,17 +273,17 @@
     <main class="flex-grow overflow-y-auto relative z-10">
       <!-- Banner de descarga del POS -->
       @if (showDownloadBanner() && downloadInfo()) {
-        <div class="flex items-center gap-4 px-6 py-3 bg-blue-600/10 border-b border-blue-500/20 text-sm">
+        <div class="flex items-center gap-2 sm:gap-4 px-3 sm:px-6 py-3 bg-blue-600/10 border-b border-blue-500/20 text-sm">
           <span class="icon-[ic--baseline-download] text-blue-400 text-lg shrink-0"></span>
-          <div class="flex-1">
-            <span class="font-bold text-white">¿Quieres usar el POS en esta computadora?</span>
-            <span class="text-slate-400 ml-2">Versión {{ downloadInfo()!.version }} disponible · {{ downloadInfo()!.fileSize }}</span>
+          <div class="flex-1 min-w-0">
+            <span class="font-bold text-white text-xs sm:text-sm">POS disponible</span>
+            <span class="hidden sm:inline text-slate-400 ml-2">¿Quieres usarlo en esta computadora? Versión {{ downloadInfo()!.version }} · {{ downloadInfo()!.fileSize }}</span>
           </div>
           <button
             (click)="downloadPOS()"
-            class="px-4 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-bold text-xs uppercase tracking-widest transition-all shrink-0"
+            class="px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-bold text-xs uppercase tracking-widest transition-all shrink-0"
           >
-            Descargar POS
+            <span class="hidden sm:inline">Descargar </span>POS
           </button>
           <button
             (click)="dismissBanner()"

--- a/frontend/web-admin/src/app/layouts/portal-layout/portal-layout.ts
+++ b/frontend/web-admin/src/app/layouts/portal-layout/portal-layout.ts
@@ -1,7 +1,8 @@
 import { Component, inject, signal, computed, OnInit, OnDestroy, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { Router, RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
+import { Router, RouterOutlet, RouterLink, RouterLinkActive, NavigationEnd } from '@angular/router';
+import { filter } from 'rxjs/operators';
 import { AuthService } from '../../core/services/auth.service';
 import { SaleService, ShiftDto } from '../../core/services/sale.service';
 import { DownloadService, DownloadInfo } from '../../core/services/download.service';
@@ -21,8 +22,9 @@ export class PortalLayout implements OnInit, OnDestroy {
   private downloads = inject(DownloadService);
   private destroyRef = inject(DestroyRef);
 
-  isSidebarCollapsed = signal(false);
-  connectionStatus   = signal<'online' | 'offline'>(navigator.onLine ? 'online' : 'offline');
+  isSidebarCollapsed   = signal(false);
+  isMobileSidebarOpen  = signal(false);
+  connectionStatus     = signal<'online' | 'offline'>(navigator.onLine ? 'online' : 'offline');
   activeShift        = signal<ShiftDto | null>(null);
   shiftElapsed       = signal('--:--:--');
   downloadInfo       = signal<DownloadInfo | null>(null);
@@ -42,6 +44,11 @@ export class PortalLayout implements OnInit, OnDestroy {
     window.addEventListener('offline', this.onOffline);
     this.loadShift();
     this.loadDownloadInfo();
+    // Close mobile sidebar on route change
+    this.router.events.pipe(
+      filter(e => e instanceof NavigationEnd),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe(() => this.isMobileSidebarOpen.set(false));
   }
 
   ngOnDestroy(): void {
@@ -95,6 +102,14 @@ export class PortalLayout implements OnInit, OnDestroy {
 
   toggleSidebar() {
     this.isSidebarCollapsed.set(!this.isSidebarCollapsed());
+  }
+
+  toggleMobileSidebar() {
+    this.isMobileSidebarOpen.set(!this.isMobileSidebarOpen());
+  }
+
+  closeMobileSidebar() {
+    this.isMobileSidebarOpen.set(false);
   }
 
   logout() {

--- a/frontend/web-admin/src/app/layouts/pos-layout/pos-layout.html
+++ b/frontend/web-admin/src/app/layouts/pos-layout/pos-layout.html
@@ -61,8 +61,12 @@
   <!-- MAIN -->
   <div class="flex flex-1 overflow-hidden">
 
-    <!-- LEFT — Catálogo -->
-    <div class="flex flex-col flex-1 overflow-hidden border-r border-white/[0.06]">
+    <!-- LEFT — Catálogo (hidden on mobile when cart is active) -->
+    <div class="flex flex-col overflow-hidden border-r border-white/[0.06]"
+         [class.hidden]="mobileView() === 'cart'"
+         [class.sm:flex]="mobileView() === 'cart'"
+         [class.flex]="mobileView() === 'catalog'"
+         [class.flex-1]="true">
 
       <!-- Barra de búsqueda + categorías -->
       <div class="px-4 py-3 space-y-2.5 bg-[#080f1e]/80 border-b border-white/[0.05] shrink-0">
@@ -176,8 +180,12 @@
       </div>
     </div>
 
-    <!-- RIGHT — Carrito -->
-    <div class="flex flex-col w-80 xl:w-96 bg-[#080f1e] shrink-0">
+    <!-- RIGHT — Carrito (full-width on mobile when cart is active, fixed-width on desktop) -->
+    <div class="flex flex-col bg-[#080f1e] shrink-0 sm:w-80 xl:w-96"
+         [class.hidden]="mobileView() === 'catalog'"
+         [class.sm:flex]="mobileView() === 'catalog'"
+         [class.flex]="mobileView() === 'cart'"
+         [class.w-full]="mobileView() === 'cart'">
 
       <!-- Carrito header -->
       <div class="flex items-center justify-between px-5 py-3.5 border-b border-white/[0.06] shrink-0">
@@ -277,6 +285,29 @@
       </div>
     </div>
   </div>
+
+  <!-- Mobile tab bar — only visible on small screens -->
+  <nav class="sm:hidden flex border-t border-white/[0.06] bg-[#080f1e] shrink-0">
+    <button (click)="mobileView.set('catalog')"
+      class="flex-1 flex flex-col items-center gap-0.5 py-2.5 text-[0.6rem] font-black uppercase tracking-widest transition-colors"
+      [class.text-blue-400]="mobileView() === 'catalog'"
+      [class.text-slate-600]="mobileView() === 'cart'">
+      <span class="icon-[ic--baseline-grid-view] text-xl"></span>
+      Catálogo
+    </button>
+    <button (click)="mobileView.set('cart')"
+      class="flex-1 flex flex-col items-center gap-0.5 py-2.5 text-[0.6rem] font-black uppercase tracking-widest transition-colors relative"
+      [class.text-blue-400]="mobileView() === 'cart'"
+      [class.text-slate-600]="mobileView() === 'catalog'">
+      <span class="relative">
+        <span class="icon-[ic--baseline-shopping-cart] text-xl"></span>
+        @if (cartCount() > 0) {
+          <span class="absolute -top-1 -right-2 min-w-[16px] h-4 px-1 rounded-full bg-blue-600 text-white text-[0.55rem] font-black flex items-center justify-center">{{ cartCount() }}</span>
+        }
+      </span>
+      Carrito
+    </button>
+  </nav>
 </div>
 
 <!-- â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•

--- a/frontend/web-admin/src/app/layouts/pos-layout/pos-layout.ts
+++ b/frontend/web-admin/src/app/layouts/pos-layout/pos-layout.ts
@@ -60,6 +60,7 @@ export class PosLayout implements OnInit, OnDestroy {
   allCustomers  = signal<CustomerSummary[]>([]);
 
   // ── UI state ─────────────────────────────────────
+  mobileView          = signal<'catalog' | 'cart'>('catalog');
   loading             = signal(false);
   saving              = signal(false);
   catalogSearch       = signal('');


### PR DESCRIPTION
## Summary

- **Portal responsive**: sidebar is now an off-canvas drawer on mobile (hamburger toggle in header, closes on navigation). Download banner, header separator, and "Nueva Venta" button are compact on mobile.
- **POS responsive**: replaced fixed split-panel with a mobile bottom tab bar (Catálogo / Carrito). Each panel is full-width on mobile. Desktop behavior unchanged.
- **Delivery/Repartidor**: added Google Maps + Waze navigation buttons for InTransit orders. Confirmar Entrega modal already had embedded MapLibre map with destination marker and driver GPS capture.
- **E2E audit**: added `responsive-audit.spec.ts` that screenshots all views at iPhone 14 (390×844) using addInitScript for auth injection.

## Root cause of responsive breakage
The portal `<aside>` sidebar had no mobile breakpoint — it occupied ~55% of a 390px viewport at all times, crushing the content area to ~155px. The POS cart panel was fixed at `w-80` (320px), leaving only ~70px for the product catalog.

## Test plan
- [ ] Open portal on a mobile device — sidebar should be hidden, hamburger opens it
- [ ] Navigate between portal pages — sidebar closes automatically
- [ ] Open POS on mobile — catalog tab shows full-width, bottom tabs switch to cart
- [ ] Open POS on desktop — original side-by-side layout unchanged
- [ ] Delivery: accept an order → status InTransit → Google Maps and Waze buttons appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)