### PR TITLE
fix(docker): rust:latest en Dockerfiles (home 0.5.12 requiere 1.88)

### DIFF
--- a/services/catalog-service/Dockerfile
+++ b/services/catalog-service/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:1.85-slim-bookworm AS builder
+FROM rust:latest AS builder
 
 RUN apt-get update && apt-get install -y \
     pkg-config libssl-dev \

--- a/services/reports-service/Dockerfile
+++ b/services/reports-service/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM rust:1.85-slim-bookworm AS builder
+FROM rust:latest AS builder
 
 RUN apt-get update && apt-get install -y \
     pkg-config libssl-dev \


### PR DESCRIPTION
Deps en Cargo.lock requieren Rust ≥1.88. Usamos rust:latest para no perseguir versiones.