### PR TITLE
fix(ci): corregir namespace GHCR — usar odimsom en vez de synsetsolutions

### DIFF
--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_ORG: synsetsolutions
+  IMAGE_ORG: odimsom
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────────
@@ -227,7 +227,7 @@ jobs:
             cd /opt/tucolmadord
             set -a; source .env; set +a
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            REGISTRY=ghcr.io/synsetsolutions TAG=${{ github.sha }} \
+            REGISTRY=ghcr.io/odimsom TAG=${{ github.sha }} \
             docker stack deploy -c docker-compose.swarm.yml tucolmadord \
               --with-registry-auth --prune
             echo "Stack deployed: SHA ${{ github.sha }}"

--- a/infrastructure/swarm/docker-compose.swarm.yml
+++ b/infrastructure/swarm/docker-compose.swarm.yml
@@ -84,7 +84,7 @@ services:
   # catalog-service — Rust/axum, 2 replicas, circuit-broken, lazy Redis cache
   # ─────────────────────────────────────────────────────────────────────────────
   catalog-service:
-    image: ${REGISTRY:-ghcr.io/synsetsolutions}/catalog-service:${TAG:-latest}
+    image: ${REGISTRY:-ghcr.io/odimsom}/catalog-service:${TAG:-latest}
     environment:
       DATABASE_URL: ${DATABASE_URL}
       REDIS_URL: redis://redis:6379
@@ -135,7 +135,7 @@ services:
   # reports-service — Rust/axum, 2 replicas, lazy computed reports
   # ─────────────────────────────────────────────────────────────────────────────
   reports-service:
-    image: ${REGISTRY:-ghcr.io/synsetsolutions}/reports-service:${TAG:-latest}
+    image: ${REGISTRY:-ghcr.io/odimsom}/reports-service:${TAG:-latest}
     environment:
       DATABASE_URL: ${DATABASE_URL}
       REDIS_URL: redis://redis:6379


### PR DESCRIPTION
## Summary
- Fix `permission_denied` al hacer push a GHCR: el workflow enviaba imágenes a `ghcr.io/synsetsolutions/...` pero `GITHUB_TOKEN` solo tiene `packages: write` bajo el dueño del repo (`odimsom`)
- Cambiado `IMAGE_ORG: synsetsolutions` → `odimsom` en el workflow y en los dos `image:` references del swarm compose

## Test plan
- [ ] Jobs `build-catalog` y `build-reports` pasan y pushean a `ghcr.io/odimsom/catalog-service` y `ghcr.io/odimsom/reports-service`
- [ ] `deploy-swarm` se ejecuta con el tag correcto

🤖 Generated with [Claude Code](https://claude.com/claude-code)