### PR TITLE
feat(ci): workflow_dispatch para forzar build sin cambios en los servicios

### DIFF
--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -1,6 +1,12 @@
 name: CI — Rust Microservices & Gateway
 
 on:
+  workflow_dispatch:
+    inputs:
+      force_build:
+        description: 'Force build+push images even without service changes'
+        required: false
+        default: 'true'
   push:
     branches: [dev, qa, main]
     paths:
@@ -28,9 +34,9 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      catalog: ${{ steps.filter.outputs.catalog }}
-      reports: ${{ steps.filter.outputs.reports }}
-      swarm:   ${{ steps.filter.outputs.swarm }}
+      catalog: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.catalog }}
+      reports: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.reports }}
+      swarm:   ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.swarm }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_ORG: synsetsolutions
+  IMAGE_ORG: odimsom
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────────
@@ -227,7 +227,7 @@ jobs:
             cd /opt/tucolmadord
             set -a; source .env; set +a
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            REGISTRY=ghcr.io/synsetsolutions TAG=${{ github.sha }} \
+            REGISTRY=ghcr.io/odimsom TAG=${{ github.sha }} \
             docker stack deploy -c docker-compose.swarm.yml tucolmadord \
               --with-registry-auth --prune
             echo "Stack deployed: SHA ${{ github.sha }}"

--- a/infrastructure/swarm/docker-compose.swarm.yml
+++ b/infrastructure/swarm/docker-compose.swarm.yml
@@ -84,7 +84,7 @@ services:
   # catalog-service — Rust/axum, 2 replicas, circuit-broken, lazy Redis cache
   # ─────────────────────────────────────────────────────────────────────────────
   catalog-service:
-    image: ${REGISTRY:-ghcr.io/synsetsolutions}/catalog-service:${TAG:-latest}
+    image: ${REGISTRY:-ghcr.io/odimsom}/catalog-service:${TAG:-latest}
     environment:
       DATABASE_URL: ${DATABASE_URL}
       REDIS_URL: redis://redis:6379
@@ -135,7 +135,7 @@ services:
   # reports-service — Rust/axum, 2 replicas, lazy computed reports
   # ─────────────────────────────────────────────────────────────────────────────
   reports-service:
-    image: ${REGISTRY:-ghcr.io/synsetsolutions}/reports-service:${TAG:-latest}
+    image: ${REGISTRY:-ghcr.io/odimsom}/reports-service:${TAG:-latest}
     environment:
       DATABASE_URL: ${DATABASE_URL}
       REDIS_URL: redis://redis:6379


### PR DESCRIPTION
## Summary
- Agrega `workflow_dispatch` al CI de Rust Microservices para poder triggerear builds manualmente
- Cuando se dispara via dispatch, el job `changes` fuerza `catalog=true` y `reports=true` aunque los archivos no hayan cambiado
- Necesario porque el fix del namespace GHCR (odimsom) llegó a main sin cambios en los servicios, por lo que el path filter saltó los builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)