### PR TITLE
feat: agregar catalog-service y reports-service al docker compose de producción

### DIFF
--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -1,6 +1,12 @@
 name: CI — Rust Microservices & Gateway
 
 on:
+  workflow_dispatch:
+    inputs:
+      force_build:
+        description: 'Force build+push images even without service changes'
+        required: false
+        default: 'true'
   push:
     branches: [dev, qa, main]
     paths:
@@ -28,9 +34,9 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      catalog: ${{ steps.filter.outputs.catalog }}
-      reports: ${{ steps.filter.outputs.reports }}
-      swarm:   ${{ steps.filter.outputs.swarm }}
+      catalog: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.catalog }}
+      reports: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.reports }}
+      swarm:   ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.swarm }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/ci-services.yml
+++ b/.github/workflows/ci-services.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_ORG: synsetsolutions
+  IMAGE_ORG: odimsom
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────────
@@ -227,7 +227,7 @@ jobs:
             cd /opt/tucolmadord
             set -a; source .env; set +a
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            REGISTRY=ghcr.io/synsetsolutions TAG=${{ github.sha }} \
+            REGISTRY=ghcr.io/odimsom TAG=${{ github.sha }} \
             docker stack deploy -c docker-compose.swarm.yml tucolmadord \
               --with-registry-auth --prune
             echo "Stack deployed: SHA ${{ github.sha }}"

--- a/deploy-production.sh
+++ b/deploy-production.sh
@@ -187,6 +187,10 @@ echo "  ✅ Bind-mount directories ready"
 
 # 7. Run docker compose with rebuild
 echo "🐳 Rebuilding and starting Docker services..."
+# Login to GHCR to pull catalog-service and reports-service images
+if [ -n "$GHCR_TOKEN" ]; then
+  echo "$GHCR_TOKEN" | docker login ghcr.io -u odimsom --password-stdin
+fi
 docker compose pull
 docker compose up --build -d
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,6 +173,51 @@ services:
     networks:
       - tucolmadord-network
 
+  catalog-service:
+    image: ghcr.io/odimsom/catalog-service:main
+    restart: on-failure:3
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      REDIS_URL: redis://redis:6379
+      PORT: "8080"
+      RUST_LOG: "info"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      - tucolmadord-network
+
+  reports-service:
+    image: ghcr.io/odimsom/reports-service:main
+    restart: on-failure:3
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      REDIS_URL: redis://redis:6379
+      PORT: "8081"
+      CACHE_TTL_S: "600"
+      RUST_LOG: "info"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      - tucolmadord-network
+
   gateway:
     build:
       context: ./backend

--- a/infrastructure/swarm/docker-compose.swarm.yml
+++ b/infrastructure/swarm/docker-compose.swarm.yml
@@ -84,7 +84,7 @@ services:
   # catalog-service — Rust/axum, 2 replicas, circuit-broken, lazy Redis cache
   # ─────────────────────────────────────────────────────────────────────────────
   catalog-service:
-    image: ${REGISTRY:-ghcr.io/synsetsolutions}/catalog-service:${TAG:-latest}
+    image: ${REGISTRY:-ghcr.io/odimsom}/catalog-service:${TAG:-latest}
     environment:
       DATABASE_URL: ${DATABASE_URL}
       REDIS_URL: redis://redis:6379
@@ -135,7 +135,7 @@ services:
   # reports-service — Rust/axum, 2 replicas, lazy computed reports
   # ─────────────────────────────────────────────────────────────────────────────
   reports-service:
-    image: ${REGISTRY:-ghcr.io/synsetsolutions}/reports-service:${TAG:-latest}
+    image: ${REGISTRY:-ghcr.io/odimsom}/reports-service:${TAG:-latest}
     environment:
       DATABASE_URL: ${DATABASE_URL}
       REDIS_URL: redis://redis:6379


### PR DESCRIPTION
## Summary
- Agrega `catalog-service` y `reports-service` al `docker-compose.yml` principal para que el gateway pueda resolverlos por hostname en `tucolmadord-network`
- Agrega login a GHCR en `deploy-production.sh` para que el VPS pueda hacer pull de las imágenes privadas
- Necesita que `GHCR_TOKEN` esté en el `.env` del VPS

## Root cause del 500
El gateway intentaba conectar a `http://reports-service:8081` pero ese container no existía en el compose stack.

## Test plan
- [ ] `/gateway/api/v1/reports/sales?tenant_id=...` devuelve 200
- [ ] `/gateway/api/v1/reports/inventory?tenant_id=...` devuelve 200
- [ ] `/gateway/api/v1/reports/customers?tenant_id=...` devuelve 200
- [ ] `docker compose ps` muestra `catalog-service` y `reports-service` healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)