### PR TITLE
fix(deploy): force-remove all tucolmadord- containers before compose up

### DIFF
--- a/deploy-production.sh
+++ b/deploy-production.sh
@@ -123,6 +123,9 @@ echo "🧹 Aggressive cleanup of old Docker artifacts..."
 echo "  Stopping and removing all tucolmadord containers..."
 docker ps -q --filter "label=com.docker.compose.project=tucolmadord" | xargs -r docker rm -f 2>/dev/null || true
 docker compose down --remove-orphans 2>/dev/null || true
+# Also force-remove any containers with the tucolmadord- name prefix that may have
+# been started outside of compose (manual runs) and therefore lack compose labels
+docker ps -aq --filter "name=tucolmadord-" | xargs -r docker rm -f 2>/dev/null || true
 
 # 4b. Remove ALL tucolmadord Named volumes explicitly (with force if they're in use)
 echo "  Removing Named volumes..."


### PR DESCRIPTION
## Summary

- `docker compose down` only removes containers that carry the compose project label
- Containers started manually (`docker run --name tucolmadord-X-1`) lack that label and survive across deploys
- The next `docker compose up` then crashes with "container name already in use"

This fix adds a name-prefix filter after `compose down` to catch any stragglers:
\`\`\`bash
docker ps -aq --filter "name=tucolmadord-" | xargs -r docker rm -f 2>/dev/null || true
\`\`\`

Observed failures: CD run #116 (prometheus-1 conflict), previous manual fixes for prometheus-1 and grafana-1.

## Test plan
- [ ] Merge into dev → qa → main and confirm CD run #117+ completes without container conflict errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)