### PR TITLE
fix(devops): redirect devops.tucolmadord.com/ to /grafana/

### DIFF
--- a/infrastructure/swarm/docker-compose.swarm.yml
+++ b/infrastructure/swarm/docker-compose.swarm.yml
@@ -324,6 +324,15 @@ services:
         - traefik.http.routers.grafana.tls.certresolver=letsencrypt
         - traefik.http.services.grafana.loadbalancer.server.port=3000
         - traefik.docker.network=monitoring-net
+        - traefik.http.routers.devops-root.rule=Host(`devops.${DOMAIN}`)
+        - traefik.http.routers.devops-root.entrypoints=websecure
+        - traefik.http.routers.devops-root.tls=true
+        - traefik.http.routers.devops-root.tls.certresolver=letsencrypt
+        - traefik.http.routers.devops-root.middlewares=devops-redirect
+        - traefik.http.routers.devops-root.service=grafana
+        - traefik.http.middlewares.devops-redirect.redirectregex.regex=^https://([^/]+)/?$$
+        - traefik.http.middlewares.devops-redirect.redirectregex.replacement=https://$${1}/grafana/
+        - traefik.http.middlewares.devops-redirect.redirectregex.permanent=true
 
   loki:
     image: grafana/loki:3.1.0


### PR DESCRIPTION
## Summary
- Adds a `devops-root` Traefik router on the Grafana service that permanently redirects bare domain requests (`devops.tucolmadord.com/`) to `/grafana/`
- Uses `redirectregex` middleware matching `^https://([^/]+)/?$` so only root hits are redirected; `/grafana/*` traffic continues to route via the existing `grafana` router (higher priority due to PathPrefix specificity)

## Test plan
- [ ] After CD deploys, visit `https://devops.tucolmadord.com` — should 301 → `https://devops.tucolmadord.com/grafana/`
- [ ] Visit `https://devops.tucolmadord.com/grafana/` directly — should still work
- [ ] Visit `https://devops.tucolmadord.com/prometheus` — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)