### PR TITLE
fix(devops): redirect devops.tucolmadord.com root to /grafana/

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -376,6 +376,15 @@ services:
       - traefik.http.routers.devops-grafana.tls=true
       - traefik.http.routers.devops-grafana.tls.certresolver=letsencrypt
       - traefik.http.services.devops-grafana.loadbalancer.server.port=3000
+      - traefik.http.routers.devops-root.rule=Host(`${PUBLIC_DEVOPS_DOMAIN:-devops.tucolmadord.com}`)
+      - traefik.http.routers.devops-root.entrypoints=websecure
+      - traefik.http.routers.devops-root.tls=true
+      - traefik.http.routers.devops-root.tls.certresolver=letsencrypt
+      - traefik.http.routers.devops-root.middlewares=devops-redirect
+      - traefik.http.routers.devops-root.service=devops-grafana
+      - traefik.http.middlewares.devops-redirect.redirectregex.regex=^https://([^/]+)/?$$
+      - traefik.http.middlewares.devops-redirect.redirectregex.replacement=https://$${1}/grafana/
+      - traefik.http.middlewares.devops-redirect.redirectregex.permanent=true
     depends_on:
       - prometheus
     networks:


### PR DESCRIPTION
## Summary
- Adds `devops-root` Traefik router + `devops-redirect` middleware to the `grafana` service in the root `docker-compose.yml`
- Permanently redirects `devops.tucolmadord.com/` → `devops.tucolmadord.com/grafana/` (301)
- The existing `devops-grafana` router (PathPrefix rule = higher priority in Traefik) keeps serving all `/grafana/*` traffic unchanged

**Root cause**: the fix was previously applied only to `infrastructure/swarm/docker-compose.swarm.yml` but the active deployment uses the root `docker-compose.yml` at `/app/tucolmadord/`.

## Test plan
- [ ] After CD deploys, `curl -I https://devops.tucolmadord.com` → `301 Location: https://devops.tucolmadord.com/grafana/`
- [ ] `https://devops.tucolmadord.com/grafana/` still loads dashboard directly
- [ ] `https://devops.tucolmadord.com/prometheus` still accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)