### PR TITLE
fix(presentations): presentations page always showed empty list

### DIFF
--- a/backend/src/core/TuColmadoRD.Core.Application/Modules/Inventory/DTOs/PresentationDto.cs
+++ b/backend/src/core/TuColmadoRD.Core.Application/Modules/Inventory/DTOs/PresentationDto.cs
@@ -4,9 +4,9 @@ public sealed record PresentationDto(
     Guid Id,
     Guid ProductId,
     string DisplayName,
-    int PresentationTypeId,
+    int PresentationType,
     string PresentationTypeName,
-    int SellModeId,
+    int SellMode,
     string SellModeName,
     int MeasureUnit,
     string? Brand,
@@ -15,4 +15,6 @@ public sealed record PresentationDto(
     decimal CostPrice,
     bool IsActive,
     DateTime CreatedAt,
-    DateTime UpdatedAt);
+    DateTime UpdatedAt,
+    int PackagedStockQuantity,
+    int OpenContainersCount);

--- a/backend/src/core/TuColmadoRD.Core.Application/Modules/Inventory/Handlers/GetPresentationsByProductQueryHandler.cs
+++ b/backend/src/core/TuColmadoRD.Core.Application/Modules/Inventory/Handlers/GetPresentationsByProductQueryHandler.cs
@@ -4,6 +4,7 @@ using TuColmadoRD.Core.Application.Inventory.Abstractions;
 using TuColmadoRD.Core.Application.Inventory.DTOs;
 using TuColmadoRD.Core.Application.Inventory.Queries;
 using TuColmadoRD.Core.Domain.Base.Result;
+using TuColmadoRD.Core.Domain.Enums.Inventory_Purchasing;
 using TuColmadoRD.Core.Domain.ValueObjects.Base;
 
 namespace TuColmadoRD.Core.Application.Inventory.Handlers;
@@ -13,13 +14,19 @@ public sealed class GetPresentationsByProductQueryHandler
 {
     private readonly ITenantProvider _tenantProvider;
     private readonly IPresentationRepository _presentationRepository;
+    private readonly IPackagedStockRepository _packagedStockRepository;
+    private readonly IStockContainerRepository _stockContainerRepository;
 
     public GetPresentationsByProductQueryHandler(
         ITenantProvider tenantProvider,
-        IPresentationRepository presentationRepository)
+        IPresentationRepository presentationRepository,
+        IPackagedStockRepository packagedStockRepository,
+        IStockContainerRepository stockContainerRepository)
     {
-        _tenantProvider         = tenantProvider;
-        _presentationRepository = presentationRepository;
+        _tenantProvider           = tenantProvider;
+        _presentationRepository   = presentationRepository;
+        _packagedStockRepository  = packagedStockRepository;
+        _stockContainerRepository = stockContainerRepository;
     }
 
     public async Task<OperationResult<IReadOnlyList<PresentationDto>, DomainError>> Handle(
@@ -28,23 +35,44 @@ public sealed class GetPresentationsByProductQueryHandler
         var tenantId = (Guid)_tenantProvider.TenantId;
         var presentations = await _presentationRepository.GetByProductIdAsync(request.ProductId, tenantId, cancellationToken);
 
+        if (presentations.Count == 0)
+            return OperationResult<IReadOnlyList<PresentationDto>, DomainError>.Good([]);
+
+        var stockTasks = presentations
+            .Select(p => _packagedStockRepository.GetByPresentationIdAsync(p.Id, tenantId, cancellationToken))
+            .ToList();
+        var containerTasks = presentations
+            .Select(p => _stockContainerRepository.GetByPresentationIdAsync(p.Id, tenantId, cancellationToken))
+            .ToList();
+
+        var allStocks     = await Task.WhenAll(stockTasks);
+        var allContainers = await Task.WhenAll(containerTasks);
+
         var dtos = presentations
-            .Select(p => new PresentationDto(
-                p.Id,
-                p.ProductId,
-                p.DisplayName,
-                p.PresentationType.Id,
-                p.PresentationType.Name,
-                p.SellMode.Id,
-                p.SellMode.Name,
-                (int)p.MeasureUnit,
-                p.Brand,
-                p.NominalCapacity,
-                p.SalePrice.Amount,
-                p.CostPrice.Amount,
-                p.IsActive,
-                p.CreatedAt,
-                p.UpdatedAt))
+            .Select((p, i) =>
+            {
+                var pkgQty     = allStocks[i]?.Quantity ?? 0;
+                var openCount  = allContainers[i].Count(c => c.Status != ContainerStatus.Empty);
+
+                return new PresentationDto(
+                    p.Id,
+                    p.ProductId,
+                    p.DisplayName,
+                    p.PresentationType.Id,
+                    p.PresentationType.Name,
+                    p.SellMode.Id,
+                    p.SellMode.Name,
+                    (int)p.MeasureUnit,
+                    p.Brand,
+                    p.NominalCapacity,
+                    p.SalePrice.Amount,
+                    p.CostPrice.Amount,
+                    p.IsActive,
+                    p.CreatedAt,
+                    p.UpdatedAt,
+                    pkgQty,
+                    openCount);
+            })
             .ToList();
 
         return OperationResult<IReadOnlyList<PresentationDto>, DomainError>.Good(dtos);

--- a/frontend/web-admin/src/app/features/portal/presentations/presentations.ts
+++ b/frontend/web-admin/src/app/features/portal/presentations/presentations.ts
@@ -2,6 +2,7 @@ import { Component, inject, OnInit, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
+import { forkJoin } from 'rxjs';
 import { InventoryService } from '../../../core/services/inventory.service';
 import { RdCurrencyPipe } from '../../../core/pipes';
 import type { ProductPresentationDto, StockContainerDto, CategoryDto } from '../../../core/services/inventory.service';
@@ -72,10 +73,13 @@ export class Presentations implements OnInit {
 
   load(): void {
     this.loading.set(true);
-    this.inventory.getProductById(this.productId()).subscribe({
-      next: product => {
+    forkJoin({
+      product: this.inventory.getProductById(this.productId()),
+      presentations: this.inventory.getPresentations(this.productId()),
+    }).subscribe({
+      next: ({ product, presentations }) => {
         this.productName.set(product.name);
-        this.presentations.set(product.presentations ?? []);
+        this.presentations.set(presentations);
         this.loading.set(false);
       },
       error: () => this.loading.set(false),


### PR DESCRIPTION
## Summary

- **Bug**: La página de presentaciones siempre mostraba "No hay presentaciones" aunque el POST de crear presentación devolvía 201.
- **3 causas encadenadas corregidas:**
  1. El componente llamaba `getProductById()` y leía `product.presentations`, pero `ProductDto` nunca incluye presentaciones → siempre `undefined → []`.
  2. `PresentationDto` tenía campos `PresentationTypeId`/`SellModeId` pero el frontend esperaba `presentationType`/`sellMode` → mismatch de nombres en JSON.
  3. `PresentationDto` no tenía `packagedStockQuantity` ni `openContainersCount` → los contadores de stock siempre mostraban 0 o NaN.

## Changes

- `GetPresentationsByProductQueryHandler`: inyecta `IPackagedStockRepository` y `IStockContainerRepository`, carga stock en paralelo por presentación.
- `PresentationDto`: renombra `PresentationTypeId → PresentationType`, `SellModeId → SellMode`; agrega `PackagedStockQuantity` y `OpenContainersCount`.
- `presentations.ts`: `load()` ahora usa `forkJoin(getProductById, getPresentations)` en vez de depender de `product.presentations`.

## Test plan

- [ ] Abrir la página de presentaciones de un producto → muestra las presentaciones existentes
- [ ] Crear una presentación → se agrega a la lista inmediatamente al guardar
- [ ] Los contadores (Total, Activas, Unidades empacadas, Contenedores abiertos) muestran valores correctos
- [ ] Build backend: 0 errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)