### PR TITLE
fix(webapp): quitar -- en pnpm run build del Dockerfile

### DIFF
--- a/frontend/web-admin/Dockerfile
+++ b/frontend/web-admin/Dockerfile
@@ -8,7 +8,7 @@ RUN pnpm install --frozen-lockfile
 
 COPY . .
 ARG BUILD_CONFIG=production
-RUN pnpm run build -- --configuration=$BUILD_CONFIG
+RUN pnpm run build --configuration=$BUILD_CONFIG
 
 FROM nginx:1.27-alpine
 RUN apk add --no-cache curl


### PR DESCRIPTION
## Problema

El CD falló con:

```
Option '--' has been specified multiple times.
Error: Schema validation failed with the following errors:
  Data path "" must NOT have additional properties().
```

`pnpm run build -- --configuration=production` pasa el `--` literal a Angular CLI. Con npm funciona porque npm lo consume; pnpm lo reenvía directamente al script.

## Fix

```diff
- RUN pnpm run build -- --configuration=$BUILD_CONFIG
+ RUN pnpm run build --configuration=$BUILD_CONFIG
```

Un solo caracter, un solo archivo.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)