### PR TITLE
fix(docker): ampliar build context a ./frontend para shared/

### DIFF
--- a/frontend/web-admin/Dockerfile
+++ b/frontend/web-admin/Dockerfile
@@ -3,14 +3,20 @@ WORKDIR /app
 
 RUN npm install -g pnpm@latest
 
-COPY package.json pnpm-lock.yaml ./
+# Deps primero (cache layer)
+COPY web-admin/package.json web-admin/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
-COPY . .
+# Tokens compartidos: van a /shared/ para que styles.css los resuelva via ../../shared/
+COPY shared/ /shared/
+
+# Código fuente del webapp
+COPY web-admin/ .
+
 ARG BUILD_CONFIG=production
 RUN pnpm run build --configuration=$BUILD_CONFIG
 
 FROM nginx:1.27-alpine
 RUN apk add --no-cache curl
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY web-admin/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist/web-admin/browser /usr/share/nginx/html


### PR DESCRIPTION
## Problema

El CD falló con:

```
Error: Can't resolve '../../shared/design-tokens.css' in '/app/src'
```

`styles.css` importa `../../shared/design-tokens.css` que está en `frontend/shared/`. El build context era `./frontend/web-admin` — la carpeta `shared/` quedaba completamente fuera del contexto Docker.

## Fix

**`docker-compose.yml`**
```diff
- context: ./frontend/web-admin
- dockerfile: Dockerfile
+ context: ./frontend
+ dockerfile: web-admin/Dockerfile
```

**`frontend/web-admin/Dockerfile`**
- Rutas de COPY ajustadas al nuevo contexto (`web-admin/package.json`, etc.)
- `COPY shared/ /shared/` coloca los tokens donde Tailwind los espera (`../../shared/design-tokens.css` desde `/app/src/` → `/shared/design-tokens.css`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)