### PR TITLE
fix(docker): corregir context del servicio web en docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -316,8 +316,8 @@ services:
 
   web:
     build:
-      context: ./frontend/web-admin
-      dockerfile: Dockerfile
+      context: ./frontend
+      dockerfile: web-admin/Dockerfile
     restart: on-failure:3
     ports:
       - "${WEB_PORT:-8083}:80"


### PR DESCRIPTION
## Root cause

PR #201 actualizó el Dockerfile para operar con context `./frontend` (rutas `COPY web-admin/...` y `COPY shared/ /shared/`) pero el campo `context` en `docker-compose.yml` no fue incluido en el commit — quedó apuntando a `./frontend/web-admin`.

Con ese context incorrecto, Docker no podía ver `shared/` y Tailwind fallaba al resolver `@import "../../shared/design-tokens.css"` en `styles.css`.

## Cambio

```yaml
# docker-compose.yml
web:
  build:
    context: ./frontend          # era: ./frontend/web-admin
    dockerfile: web-admin/Dockerfile  # era: Dockerfile
```

## Test plan

- [ ] CD build llega al paso Angular sin error de resolución de CSS
- [ ] `dist/web-admin/browser` se genera correctamente
- [ ] Nginx sirve el SPA en producción

🤖 Generated with [Claude Code](https://claude.com/claude-code)