### PR TITLE
fix(ci): usar pnpm en el build del instalador Windows

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -85,6 +85,11 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -96,7 +101,7 @@ jobs:
 
       - name: Install web-admin dependencies
         working-directory: ./frontend/web-admin
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Build desktop + installer
         run: |


### PR DESCRIPTION
## Problema

Al migrar `web-admin` a pnpm (PR #195), se eliminó `package-lock.json` y solo existe `pnpm-lock.yaml`. El job `Build & Attach Installer to Release` en el CD seguía usando `npm ci`, que requiere `package-lock.json` → falla con `EUSAGE`.

## Cambio

- Agrega `pnpm/action-setup@v4` antes del paso de instalación
- Cambia `npm ci` → `pnpm install --frozen-lockfile`

## Impacto

Solo afecta el job del instalador Windows. El deploy a producción ya pasa correctamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)