### PR TITLE
fix(landing): imágenes rotas, footer y limpieza de referencias WhatsApp

### DIFF
--- a/frontend/landing-page/src/components/layout/Footer.vue
+++ b/frontend/landing-page/src/components/layout/Footer.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Icon } from '@iconify/vue'
 import AppLogo from '@/components/ui/AppLogo.vue'
 </script>
 
@@ -9,23 +8,12 @@ import AppLogo from '@/components/ui/AppLogo.vue'
       <div class="grid grid-cols-1 md:grid-cols-4 gap-16 mb-20">
         <div class="col-span-1 md:col-span-2">
           <AppLogo class="mb-8 brightness-0 invert opacity-80" />
-          <p class="text-neutral-content/60 max-w-sm mb-10 text-lg leading-relaxed">
-            La plataforma líder en digitalización de colmados en la República Dominicana. 
+          <p class="text-neutral-content/60 max-w-sm text-lg leading-relaxed">
+            La plataforma líder en digitalización de colmados en la República Dominicana.
             Llevando la tradición al siguiente nivel tecnológico.
           </p>
-          <div class="flex gap-6">
-            <a href="#" class="text-neutral-content/40 hover:text-primary transition-colors">
-              <Icon icon="lucide:facebook" class="w-7 h-7" />
-            </a>
-            <a href="#" class="text-neutral-content/40 hover:text-primary transition-colors">
-              <Icon icon="lucide:instagram" class="w-7 h-7" />
-            </a>
-            <a href="#" class="text-neutral-content/40 hover:text-primary transition-colors">
-              <Icon icon="lucide:twitter" class="w-7 h-7" />
-            </a>
-          </div>
         </div>
-        
+
         <div>
           <h4 class="text-neutral-content font-black mb-8 uppercase tracking-[0.3em] text-xs">Explorar</h4>
           <ul class="space-y-4 text-neutral-content/50 font-bold uppercase tracking-widest text-xs">
@@ -39,9 +27,8 @@ import AppLogo from '@/components/ui/AppLogo.vue'
         <div>
           <h4 class="text-neutral-content font-black mb-8 uppercase tracking-[0.3em] text-xs">Legal</h4>
           <ul class="space-y-4 text-neutral-content/50 font-bold uppercase tracking-widest text-xs">
-            <li><a href="#" class="hover:text-neutral-content transition-colors">Términos</a></li>
-            <li><a href="#" class="hover:text-neutral-content transition-colors">Privacidad</a></li>
-            <li><a href="#" class="hover:text-neutral-content transition-colors">Cookies</a></li>
+            <li><span class="text-neutral-content/30">Términos — próximamente</span></li>
+            <li><span class="text-neutral-content/30">Privacidad — próximamente</span></li>
           </ul>
         </div>
       </div>
@@ -49,7 +36,7 @@ import AppLogo from '@/components/ui/AppLogo.vue'
       <div class="pt-10 border-t border-neutral-content/5 flex flex-col md:flex-row justify-between items-center gap-6 text-xs font-bold uppercase tracking-widest text-neutral-content/30">
         <p>© 2026 TuColmadoRD. Marca Registrada.</p>
         <p>
-          Socio Tecnológico: 
+          Creado por
           <a href="https://synsetsolutions.com" target="_blank" class="text-primary hover:text-neutral-content transition-colors">
             Synset Solutions
           </a>

--- a/frontend/landing-page/src/views/home/sections/Cta.vue
+++ b/frontend/landing-page/src/views/home/sections/Cta.vue
@@ -9,7 +9,7 @@ const { registerUrl } = useWebAdmin()
 </script>
 
 <template>
-  <section class="py-32 bg-secondary relative overflow-hidden">
+  <section id="contacto" class="py-32 bg-secondary relative overflow-hidden">
     <div class="absolute inset-0 opacity-10">
       <div class="absolute top-0 left-0 w-96 h-96 bg-secondary-content rounded-full -translate-x-1/2 -translate-y-1/2 blur-3xl"></div>
       <div class="absolute bottom-0 right-0 w-96 h-96 bg-primary rounded-full translate-x-1/2 translate-y-1/2 blur-3xl"></div>

--- a/frontend/landing-page/src/views/home/sections/Features.vue
+++ b/frontend/landing-page/src/views/home/sections/Features.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import AppSection from '@/components/ui/AppSection.vue'
+import imgGestion from '@/assets/img/hero/col-picture-mobile.webp'
+import imgPedidos from '@/assets/img/hero/col-picture-desktop.webp'
 
 defineOptions({ name: 'FeaturesSection' })
 
 const sections = [
   {
-    image: '/src/assets/img/hero/col-picture-mobile.webp',
+    image: imgGestion,
     imageSide: 'left' as const,
     flagText: 'Control Total',
     flagVariant: 'secondary' as const,
@@ -25,7 +27,7 @@ const sections = [
     ]
   },
   {
-    image: '/src/assets/img/hero/col-picture-desktop.webp',
+    image: imgPedidos,
     imageSide: 'right' as const,
     flagText: 'Más Ventas',
     flagVariant: 'primary' as const,
@@ -33,7 +35,7 @@ const sections = [
     highlight: 'No Paran',
     description: 'Llega a más clientes sin esfuerzo. Tu colmado ahora está disponible 24/7 para que tus vecinos puedan pedir desde la comodidad de su hogar.',
     features: [
-      { title: 'WhatsApp Integration', icon: 'lucide:message-circle' },
+      { title: 'Pedidos en Línea', icon: 'lucide:shopping-cart' },
       { title: 'App para Clientes', icon: 'lucide:app-window' },
       { title: 'Gestión de Delivery', icon: 'lucide:truck' },
       { title: 'Pagos Digitales', icon: 'lucide:credit-card' }

--- a/frontend/landing-page/src/views/home/sections/Hero.vue
+++ b/frontend/landing-page/src/views/home/sections/Hero.vue
@@ -9,7 +9,7 @@ const { registerUrl } = useWebAdmin()
 
 const highlights = [
   { label: 'Programa Pionero', value: '20 cupos' },
-  { label: 'Soporte Humano', value: 'WhatsApp' },
+  { label: 'Soporte', value: 'Directo' },
   { label: 'Primer Año', value: 'Gratis' },
   { label: 'Cobertura', value: 'RD' },
 ]

--- a/frontend/landing-page/src/views/home/sections/HowItWorks.vue
+++ b/frontend/landing-page/src/views/home/sections/HowItWorks.vue
@@ -12,7 +12,7 @@ const steps = [
     number: '01',
     icon: 'lucide:user-plus',
     title: 'Solicita tu cupo',
-    description: 'Completa el formulario en menos de 2 minutos. Cuéntanos sobre tu colmado y te contactamos por WhatsApp para coordinar tu acceso.',
+    description: 'Completa el formulario en menos de 2 minutos. Cuéntanos sobre tu colmado y nos comunicamos contigo para coordinar tu acceso.',
   },
   {
     number: '02',

--- a/frontend/landing-page/src/views/home/sections/Pricing.vue
+++ b/frontend/landing-page/src/views/home/sections/Pricing.vue
@@ -14,8 +14,8 @@ const perks = [
     description: 'Sin límites de usuarios, facturación, inventario ni fiados. Todo incluido hasta que evaluemos juntos el siguiente paso.',
   },
   {
-    icon: 'lucide:message-circle',
-    title: 'Soporte humano por WhatsApp',
+    icon: 'lucide:headphones',
+    title: 'Soporte humano directo',
     description: 'Hablas con nosotros, no con un bot. Lunes a sábado. Entendemos tu negocio porque somos de aquí.',
   },
   {


### PR DESCRIPTION
## Cambios

### Imágenes rotas (gestión y pedidos)
**Features.vue** usaba rutas string `/src/assets/...` que Vite NO procesa en producción — los assets quedan fuera del bundle. Ahora se importan con el alias `@/assets/...` para que Vite los bundle y hashee correctamente.

### Footer limpio
- **"Socio Tecnológico"** → **"Creado por"**
- Redes sociales eliminadas (no hay cuentas activas — tener botones con `href="#"` confunde al usuario)
- Términos/Privacidad reemplazados por "próximamente" (no existen aún)
- `id="contacto"` agregado en `Cta.vue` para que el enlace del footer funcione

### Sin referencias a WhatsApp
No hay integración activa de WhatsApp. Se eliminaron todas las menciones en botones y textos:
- Hero stat: "WhatsApp" → "Directo"
- HowItWorks paso 01: se quitó "por WhatsApp"
- Pricing perk: "Soporte por WhatsApp" → "Soporte humano directo"
- Features: "WhatsApp Integration" → "Pedidos en Línea"

🤖 Generated with [Claude Code](https://claude.com/claude-code)