### PR TITLE
ci: fix SSH port 2222

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -133,6 +133,7 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
+          port: 2222
           script: |
             set -e
             cd /opt/synset/tucolmadord


### PR DESCRIPTION
Agrega port: 2222 al ssh-action (router: externo 2222 → interno 22)