### PR TITLE
ci: SSH port 22

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -133,7 +133,6 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          port: 2222
           script: |
             set -e
             cd /opt/synset/tucolmadord


### PR DESCRIPTION
Router ahora tiene externo 22 → interno 22. Quita el port: 2222 explícito.