### PR TITLE
feat: complete web-admin, fix ECF pipeline, NCF concurrency & DB indexes

### DIFF
--- a/backend/src/Presentations/TuColmadoRD.Presentation.API/Endpoints/Sales/SalesEndpoints.cs
+++ b/backend/src/Presentations/TuColmadoRD.Presentation.API/Endpoints/Sales/SalesEndpoints.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using TuColmadoRD.Core.Application.Interfaces.Tenancy;
 using TuColmadoRD.Core.Application.Sales.Abstractions;
 using TuColmadoRD.Core.Application.Sales.Commands;
@@ -50,30 +51,46 @@ public static class SalesEndpoints
 
         var command = new CreateSaleCommand(commandItems, commandPayments, request.Notes, request.BuyerRnc, deliveryAddress);
 
-        var result = await mediator.Send(command, ct);
-        if (!result.TryGetResult(out var created) || created is null)
+        // Retry hasta 3 veces si dos ventas compiten por el mismo NCF (concurrency token).
+        // El handler solo falla DbUpdateConcurrencyException por esa razón.
+        const int maxAttempts = 3;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++)
         {
-            return result.Error.MapDomainError();
+            try
+            {
+                var result = await mediator.Send(command, ct);
+                if (!result.TryGetResult(out var created) || created is null)
+                    return result.Error.MapDomainError();
+
+                var response = new CreateSaleResponse(
+                    created.SaleId,
+                    created.ReceiptNumber,
+                    created.NcfNumber,
+                    created.Subtotal,
+                    created.TotalItbis,
+                    created.Total,
+                    created.TotalPaid,
+                    created.ChangeDue,
+                    created.Items.Select(i => new CreateSaleLineResponse(
+                        i.ProductId,
+                        i.ProductName,
+                        i.Quantity,
+                        i.UnitPrice,
+                        i.LineItbis,
+                        i.LineTotal)).ToList());
+
+                return TypedResults.Created($"/api/v1/sales/{created.SaleId}", response);
+            }
+            catch (DbUpdateConcurrencyException) when (attempt < maxAttempts)
+            {
+                // Otra venta tomó el mismo NCF; reintentar con la secuencia actualizada.
+                await Task.Delay(TimeSpan.FromMilliseconds(50 * attempt), ct);
+            }
         }
 
-        var response = new CreateSaleResponse(
-            created.SaleId,
-            created.ReceiptNumber,
-            created.NcfNumber,
-            created.Subtotal,
-            created.TotalItbis,
-            created.Total,
-            created.TotalPaid,
-            created.ChangeDue,
-            created.Items.Select(i => new CreateSaleLineResponse(
-                i.ProductId,
-                i.ProductName,
-                i.Quantity,
-                i.UnitPrice,
-                i.LineItbis,
-                i.LineTotal)).ToList());
-
-        return TypedResults.Created($"/api/v1/sales/{created.SaleId}", response);
+        return TypedResults.Problem(
+            detail: "No se pudo asignar un NCF único. Intente nuevamente.",
+            statusCode: StatusCodes.Status409Conflict);
     }
 
     private static async Task<IResult> VoidSale(

--- a/backend/src/Presentations/TuColmadoRD.Presentation.API/appsettings.Development.json
+++ b/backend/src/Presentations/TuColmadoRD.Presentation.API/appsettings.Development.json
@@ -7,5 +7,9 @@
   },
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=54329;Database=TuColmadoDb;Username=postgres;Password=1234"
+  },
+  "EcfGenerator": {
+    "BaseUrl": "http://localhost:5000",
+    "TimeoutSeconds": 10
   }
 }

--- a/backend/src/core/TuColmadoRD.Core.Application/Modules/Sales/Handlers/CreateSaleCommandHandler.cs
+++ b/backend/src/core/TuColmadoRD.Core.Application/Modules/Sales/Handlers/CreateSaleCommandHandler.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using TuColmadoRD.Core.Application.Interfaces.Tenancy;
 using TuColmadoRD.Core.Application.Inventory.Abstractions;
 using TuColmadoRD.Core.Application.Sales.Abstractions;
@@ -44,6 +45,7 @@ public sealed class CreateSaleCommandHandler : IRequestHandler<CreateSaleCommand
     private readonly IEcfSignerService _ecfSignerService;
     private readonly ITenantProfileRepository _tenantProfileRepository;
     private readonly IDeliveryOrderRepository _deliveryOrderRepository;
+    private readonly ILogger<CreateSaleCommandHandler> _logger;
 
     public CreateSaleCommandHandler(
         ITenantProvider tenantProvider,
@@ -62,7 +64,8 @@ public sealed class CreateSaleCommandHandler : IRequestHandler<CreateSaleCommand
         IEcfGeneratorClient ecfGeneratorClient,
         IEcfSignerService ecfSignerService,
         ITenantProfileRepository tenantProfileRepository,
-        IDeliveryOrderRepository deliveryOrderRepository)
+        IDeliveryOrderRepository deliveryOrderRepository,
+        ILogger<CreateSaleCommandHandler> logger)
     {
         _tenantProvider = tenantProvider;
         _shiftService = shiftService;
@@ -81,6 +84,7 @@ public sealed class CreateSaleCommandHandler : IRequestHandler<CreateSaleCommand
         _ecfSignerService = ecfSignerService;
         _tenantProfileRepository = tenantProfileRepository;
         _deliveryOrderRepository = deliveryOrderRepository;
+        _logger = logger;
     }
 
     public async Task<OperationResult<CreateSaleResult, DomainError>> Handle(
@@ -305,47 +309,67 @@ public sealed class CreateSaleCommandHandler : IRequestHandler<CreateSaleCommand
 
                 string? trackId = null;
 
+                // La generación del e-CF es un paso secundario: si el generador
+                // está caído o rechaza el payload, la venta DEBE completarse
+                // igual (el NCF ya quedó asignado y el e-CF puede reemitirse).
                 if (ncfNumber.StartsWith("E3", StringComparison.OrdinalIgnoreCase))
                 {
-                    var profile = await _tenantProfileRepository.GetByTenantAsync(tenantId, ct);
-                    if (profile is not null)
+                    try
                     {
-                        var payload = new Dictionary<string, object>
+                        var profile = await _tenantProfileRepository.GetByTenantAsync(tenantId, ct);
+                        if (profile is not null)
                         {
-                            ["TipoeCF"] = isCreditFiscal ? 31 : 32,
-                            ["eNCF"] = ncfNumber,
-                            ["RNCEmisor"] = profile.Rnc?.Value ?? "131111111",
-                            ["RazonSocialEmisor"] = profile.BusinessName,
-                            ["FechaEmision"] = DateTime.Now.ToString("dd-MM-yyyy"),
-                            ["MontoTotal"] = sale.TotalAmount,
-                            ["MontoGravadoTotal"] = sale.TotalAmount - sale.TotalItbisAmount,
-                            ["TotalITBIS"] = sale.TotalItbisAmount,
-                            ["IndicadorMontoGravado"] = "1",
-                            ["TipoIngresos"] = "01",
-                            ["TipoPago"] = "1"
-                        };
+                            var montoGravado = (sale.TotalAmount - sale.TotalItbisAmount).ToString("F2");
+                            var montoTotal  = sale.TotalAmount.ToString("F2");
+                            var totalItbis  = sale.TotalItbisAmount.ToString("F2");
 
-                        if (isCreditFiscal)
-                        {
-                            payload["RNCComprador"] = request.BuyerRnc!;
-                            payload["RazonSocialComprador"] = "CLIENTE CREDITO FISCAL";
+                            var payload = new Dictionary<string, object>
+                            {
+                                ["TipoeCF"] = isCreditFiscal ? 31 : 32,
+                                ["eNCF"] = ncfNumber,
+                                ["RNCEmisor"] = profile.Rnc?.Value ?? "131111111",
+                                ["RazonSocialEmisor"] = profile.BusinessName,
+                                ["DireccionEmisor"] = profile.BusinessAddress,
+                                ["FechaEmision"] = DateTime.Now.ToString("dd-MM-yyyy"),
+                                ["MontoGravadoTotal"] = montoGravado,
+                                ["TotalITBIS"] = totalItbis,
+                                ["TotalITBIS1"] = totalItbis,
+                                ["ITBIS1"] = "18",
+                                ["MontoTotal"] = montoTotal,
+                                ["ValorPagar"] = montoTotal,
+                                ["IndicadorMontoGravado"] = "1",
+                                ["TipoIngresos"] = "01",
+                                ["TipoPago"] = "1"
+                            };
+
+                            if (isCreditFiscal)
+                            {
+                                payload["RNCComprador"] = request.BuyerRnc!;
+                                payload["RazonSocialComprador"] = "CLIENTE CREDITO FISCAL";
+                            }
+
+                            for (int i = 0; i < saleItemResults.Count; i++)
+                            {
+                                payload[$"Item_{i+1}_NumeroLinea"] = i + 1;
+                                payload[$"Item_{i+1}_NombreItem"] = saleItemResults[i].ProductName;
+                                payload[$"Item_{i+1}_CantidadItem"] = saleItemResults[i].Quantity;
+                                payload[$"Item_{i+1}_PrecioUnitarioItem"] = saleItemResults[i].UnitPrice.ToString("F2");
+                                payload[$"Item_{i+1}_MontoItem"] = saleItemResults[i].LineTotal.ToString("F2");
+                                payload[$"Item_{i+1}_IndicadorBienoServicio"] = "1";
+                                payload[$"Item_{i+1}_IndicadorFacturacion"] = "1";
+                            }
+
+                            var xmlRaw = await _ecfGeneratorClient.GenerateXmlAsync(payload);
+                            var signedXml = await _ecfSignerService.SignXmlAsync(xmlRaw, tenantId);
+
+                            trackId = $"MOCK_DGII_TRACKID_{Guid.NewGuid().ToString("N")[..8]}";
                         }
-
-                        for (int i = 0; i < saleItemResults.Count; i++)
-                        {
-                            payload[$"Item_{i+1}_NumeroLinea"] = i + 1;
-                            payload[$"Item_{i+1}_NombreItem"] = saleItemResults[i].ProductName;
-                            payload[$"Item_{i+1}_CantidadItem"] = saleItemResults[i].Quantity;
-                            payload[$"Item_{i+1}_PrecioUnitarioItem"] = saleItemResults[i].UnitPrice;
-                            payload[$"Item_{i+1}_MontoItem"] = saleItemResults[i].LineTotal;
-                            payload[$"Item_{i+1}_IndicadorBienoServicio"] = 1;
-                            payload[$"Item_{i+1}_IndicadorFacturacion"] = 1;
-                        }
-
-                        var xmlRaw = await _ecfGeneratorClient.GenerateXmlAsync(payload);
-                        var signedXml = await _ecfSignerService.SignXmlAsync(xmlRaw, tenantId);
-
-                        trackId = $"MOCK_DGII_TRACKID_{Guid.NewGuid().ToString("N")[..8]}";
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        _logger.LogWarning(ex,
+                            "Fallo al generar/firmar e-CF {Ncf} para el tenant {TenantId}; la venta continúa sin TrackId.",
+                            ncfNumber, tenantId);
                     }
                 }
 

--- a/backend/src/infrastructure/TuColmadoRD.Infrastructure.CrossCutting/Network/EcfGeneratorClient.cs
+++ b/backend/src/infrastructure/TuColmadoRD.Infrastructure.CrossCutting/Network/EcfGeneratorClient.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using TuColmadoRD.Core.Application.Interfaces.Services;
 
 namespace TuColmadoRD.Infrastructure.CrossCutting.Network;
@@ -10,27 +13,35 @@ namespace TuColmadoRD.Infrastructure.CrossCutting.Network;
 public class EcfGeneratorClient : IEcfGeneratorClient
 {
     private readonly HttpClient _httpClient;
+    private readonly ILogger<EcfGeneratorClient> _logger;
 
-    public EcfGeneratorClient(HttpClient httpClient)
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public EcfGeneratorClient(HttpClient httpClient, ILogger<EcfGeneratorClient> logger)
     {
         _httpClient = httpClient;
+        _logger = logger;
     }
 
     public async Task<string> GenerateXmlAsync(object payload)
     {
         var response = await _httpClient.PostAsJsonAsync("/api/v1/ecf/generate", payload);
-        
+
         if (!response.IsSuccessStatusCode)
         {
             var err = await response.Content.ReadAsStringAsync();
             throw new InvalidOperationException($"Error calling python ECF generator: {err}");
         }
 
-        var result = await response.Content.ReadFromJsonAsync<EcfGeneratorResponse>();
+        var result = await response.Content.ReadFromJsonAsync<EcfGeneratorResponse>(_jsonOptions);
         if (result == null || string.IsNullOrWhiteSpace(result.Xml))
-        {
             throw new InvalidOperationException("Python ECF generator returned an empty XML.");
-        }
+
+        foreach (var warning in result.Warnings)
+            _logger.LogWarning("ECF XSD warning: {Warning}", warning);
 
         return result.Xml;
     }
@@ -38,6 +49,12 @@ public class EcfGeneratorClient : IEcfGeneratorClient
 
 public class EcfGeneratorResponse
 {
+    [JsonPropertyName("xml")]
     public string Xml { get; set; } = string.Empty;
+
+    [JsonPropertyName("filename")]
     public string Filename { get; set; } = string.Empty;
+
+    [JsonPropertyName("warnings")]
+    public List<string> Warnings { get; set; } = new();
 }

--- a/backend/src/infrastructure/TuColmadoRD.Infrastructure.CrossCutting/ServiceRegistration.cs
+++ b/backend/src/infrastructure/TuColmadoRD.Infrastructure.CrossCutting/ServiceRegistration.cs
@@ -27,10 +27,14 @@ public static class ServiceRegistration
         services.AddSingleton<TuColmadoRD.Core.Application.Interfaces.Security.IClock, SystemClock>();
         services.AddScoped<TuColmadoRD.Core.Application.Interfaces.Services.IEcfSignerService, EcfSignerService>();
 
-        services.AddHttpClient<TuColmadoRD.Core.Application.Interfaces.Services.IEcfGeneratorClient, EcfGeneratorClient>(client => 
+        services.AddHttpClient<TuColmadoRD.Core.Application.Interfaces.Services.IEcfGeneratorClient, EcfGeneratorClient>(client =>
         {
             var baseUrl = configuration["EcfGenerator:BaseUrl"] ?? "http://ecf-generator:5000";
             client.BaseAddress = new Uri(baseUrl);
+            // El generador corre en el camino de cobro del POS: si no responde
+            // rápido se aborta y la venta sigue sin e-CF (no esperar los 100s default).
+            client.Timeout = TimeSpan.FromSeconds(
+                configuration.GetValue<int?>("EcfGenerator:TimeoutSeconds") ?? 10);
         });
 
         var applicationAssembly = typeof(TuColmadoRD.Core.Application.Behaviors.ICommandMarker).Assembly;

--- a/backend/src/infrastructure/TuColmadoRD.Infrastructure.Persistence/EntitiesConfigurations/Customers/CustomerConfiguration.cs
+++ b/backend/src/infrastructure/TuColmadoRD.Infrastructure.Persistence/EntitiesConfigurations/Customers/CustomerConfiguration.cs
@@ -19,6 +19,7 @@ public class CustomerConfiguration : IEntityTypeConfiguration<Customer>
         builder.OwnsOne(c => c.TenantId, b => 
         {
             b.Property(t => t.Value).HasColumnName("TenantId").IsRequired();
+            b.HasIndex(t => t.Value).HasDatabaseName("IX_Customers_TenantId");
         });
 
         builder.OwnsOne(c => c.DocumentId, b => 

--- a/backend/src/infrastructure/TuColmadoRD.Infrastructure.Persistence/EntitiesConfigurations/Fiscal/FiscalSequenceConfiguration.cs
+++ b/backend/src/infrastructure/TuColmadoRD.Infrastructure.Persistence/EntitiesConfigurations/Fiscal/FiscalSequenceConfiguration.cs
@@ -11,12 +11,19 @@ public class FiscalSequenceConfiguration : IEntityTypeConfiguration<FiscalSequen
         builder.ToTable("FiscalSequences");
         builder.HasKey(fs => fs.Id);
 
-        builder.OwnsOne(fs => fs.TenantId, b => 
+        builder.OwnsOne(fs => fs.TenantId, b =>
         {
             b.Property(t => t.Value).HasColumnName("TenantId").IsRequired();
+            // Lookup de secuencia activa: siempre se busca por tenant + prefijo
+            b.HasIndex(t => t.Value).HasDatabaseName("IX_FiscalSequences_TenantId");
         });
 
-
         builder.Property(fs => fs.Prefix).IsRequired().HasMaxLength(5);
+
+        // El UPDATE solo aplica si CurrentSequence no cambió desde la lectura:
+        // dos ventas concurrentes ya no pueden emitir el mismo NCF (DGII exige
+        // numeración única); la segunda falla con DbUpdateConcurrencyException
+        // y el cliente reintenta.
+        builder.Property(fs => fs.CurrentSequence).IsConcurrencyToken();
     }
 }

--- a/backend/src/infrastructure/TuColmadoRD.Infrastructure.Persistence/EntitiesConfigurations/Inventory/ProductConfiguration.cs
+++ b/backend/src/infrastructure/TuColmadoRD.Infrastructure.Persistence/EntitiesConfigurations/Inventory/ProductConfiguration.cs
@@ -22,6 +22,7 @@ public class ProductConfiguration : IEntityTypeConfiguration<Product>
         builder.OwnsOne(p => p.TenantId, b =>
         {
             b.Property(t => t.Value).HasColumnName("TenantId").IsRequired();
+            b.HasIndex(t => t.Value).HasDatabaseName("IX_Products_TenantId");
         });
 
         builder.Property(p => p.ItbisRate)

--- a/backend/src/infrastructure/TuColmadoRD.Infrastructure.Persistence/EntitiesConfigurations/Sales/SaleConfiguration.cs
+++ b/backend/src/infrastructure/TuColmadoRD.Infrastructure.Persistence/EntitiesConfigurations/Sales/SaleConfiguration.cs
@@ -32,6 +32,7 @@ public class SaleConfiguration : IEntityTypeConfiguration<Sale>
         builder.OwnsOne(s => s.TenantId, b => 
         {
             b.Property(t => t.Value).HasColumnName("TenantId").IsRequired();
+            b.HasIndex(t => t.Value).HasDatabaseName("IX_Sales_TenantId");
         });
 
         builder.HasMany(s => s.Items)

--- a/backend/src/infrastructure/TuColmadoRD.Infrastructure.Persistence/Migrations/20260611104634_AddFiscalSequenceConcurrencyAndTenantIndexes.Designer.cs
+++ b/backend/src/infrastructure/TuColmadoRD.Infrastructure.Persistence/Migrations/20260611104634_AddFiscalSequenceConcurrencyAndTenantIndexes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TuColmadoRD.Infrastructure.Persistence.Contexts;
@@ -11,9 +12,11 @@ using TuColmadoRD.Infrastructure.Persistence.Contexts;
 namespace TuColmadoRD.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(TuColmadoDbContext))]
-    partial class TuColmadoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260611104634_AddFiscalSequenceConcurrencyAndTenantIndexes")]
+    partial class AddFiscalSequenceConcurrencyAndTenantIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/infrastructure/TuColmadoRD.Infrastructure.Persistence/Migrations/20260611104634_AddFiscalSequenceConcurrencyAndTenantIndexes.cs
+++ b/backend/src/infrastructure/TuColmadoRD.Infrastructure.Persistence/Migrations/20260611104634_AddFiscalSequenceConcurrencyAndTenantIndexes.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TuColmadoRD.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFiscalSequenceConcurrencyAndTenantIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Sales_TenantId",
+                schema: "Sales",
+                table: "Sales",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Products_TenantId",
+                schema: "Inventory",
+                table: "Products",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FiscalSequences_TenantId",
+                schema: "Fiscal",
+                table: "FiscalSequences",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Customers_TenantId",
+                schema: "Customers",
+                table: "Customers",
+                column: "TenantId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Sales_TenantId",
+                schema: "Sales",
+                table: "Sales");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Products_TenantId",
+                schema: "Inventory",
+                table: "Products");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FiscalSequences_TenantId",
+                schema: "Fiscal",
+                table: "FiscalSequences");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Customers_TenantId",
+                schema: "Customers",
+                table: "Customers");
+        }
+    }
+}

--- a/backend/tests/core/TuColmadoRD.Core.Application.Tests/Sales/SalesModuleTests.cs
+++ b/backend/tests/core/TuColmadoRD.Core.Application.Tests/Sales/SalesModuleTests.cs
@@ -68,7 +68,8 @@ public sealed class SalesModuleTests
             new Mock<TuColmadoRD.Core.Application.Interfaces.Services.IEcfGeneratorClient>().Object,
             new Mock<TuColmadoRD.Core.Application.Interfaces.Services.IEcfSignerService>().Object,
             new Mock<TuColmadoRD.Core.Domain.Interfaces.Repositories.System.ITenantProfileRepository>().Object,
-            new Mock<IDeliveryOrderRepository>().Object);
+            new Mock<IDeliveryOrderRepository>().Object,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<CreateSaleCommandHandler>.Instance);
 
         _voidSaleHandler = new VoidSaleCommandHandler(
             _tenant.Object,

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,12 +1,15 @@
+# =============================================================================
+# Stack LOCAL completo — espejo de producción pero autocontenido:
+#   docker compose -f docker-compose.local.yml up --build
+#
+#   Landing:    http://localhost:8082
+#   Web admin:  http://localhost:8083   (frontend NUEVO, build config "local")
+#   Gateway:    http://localhost:8081
+#   MailHog UI: http://localhost:8025   (correos de verificación llegan aquí)
+#
+# Sin Traefik/TLS ni monitoreo: eso es de producción (docker-compose.yml).
+# =============================================================================
 services:
-  mongo:
-    image: mongo:7
-    ports:
-      - "27017:27017"
-    volumes:
-      - mongo_local_data:/data/db
-    restart: unless-stopped
-
   postgres:
     image: postgres:15
     ports:
@@ -17,8 +20,198 @@ services:
       POSTGRES_DB: TuColmadoDb
     volumes:
       - postgres_local_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d TuColmadoDb"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped
+
+  mongo:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: tucolmado
+      MONGO_INITDB_ROOT_PASSWORD: local1234
+    volumes:
+      - mongo_local_data:/data/db
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_local_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  mailhog:
+    image: mailhog/mailhog:latest
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    restart: unless-stopped
+
+  notification-service:
+    build:
+      context: ./notification-service
+      dockerfile: Dockerfile
+    environment:
+      NODE_ENV: production
+      PORT: 4000
+      SMTP_HOST: mailhog
+      SMTP_PORT: 1025
+      SMTP_SECURE: "false"
+      SMTP_FROM: TuColmado RD <noreply@tucolmadord.local>
+      SERVICE_SECRET: local-internal-secret
+      REDIS_URL: redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
+      mailhog:
+        condition: service_started
+    ports:
+      - "4000:4000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    restart: on-failure:3
+
+  auth:
+    build:
+      context: ./auth
+      dockerfile: Dockerfile
+    environment:
+      NODE_ENV: production
+      PORT: 3000
+      MONGODB_URI: mongodb://tucolmado:local1234@mongo:27017/tu_colmado_auth?authSource=admin
+      JWT_SECRET: local-dev-secret-tucolmadord
+      JWT_EXPIRES_IN: 7d
+      NET_API_URL: http://api:8080
+      EMAIL_SERVICE_URL: http://notification-service:4000
+      SERVICE_SECRET: local-internal-secret
+    depends_on:
+      mongo:
+        condition: service_healthy
+      notification-service:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    restart: on-failure:3
+
+  ecf-generator:
+    build:
+      context: ./generadordexmle-cf
+      dockerfile: Dockerfile
+    ports:
+      - "5000:5000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    restart: on-failure:3
+
+  api:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.api
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__DefaultConnection: Host=postgres;Database=TuColmadoDb;Username=postgres;Password=1234
+      ConnectionStrings__PostgresSQLConnectionString: Host=postgres;Database=TuColmadoDb;Username=postgres;Password=1234
+      EcfGenerator__BaseUrl: http://ecf-generator:5000
+      AuthApi__BaseUrl: http://auth:3000
+      Outbox__CloudSyncBaseUrl: http://auth:3000
+      JwtSettings__Secret: local-dev-secret-tucolmadord
+    depends_on:
+      postgres:
+        condition: service_healthy
+      ecf-generator:
+        condition: service_started
+    ports:
+      - "8080:8080"
+    restart: on-failure:3
+
+  gateway:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.gateway
+    environment:
+      GatewayOptions__AuthApiUrl: http://auth:3000
+      GatewayOptions__CoreApiUrl: http://api:8080
+      GatewayOptions__JwtSecret: local-dev-secret-tucolmadord
+      GatewayOptions__AllowedOrigins__0: http://localhost:4200
+      GatewayOptions__AllowedOrigins__1: http://localhost:8082
+      GatewayOptions__AllowedOrigins__2: http://localhost:8083
+    depends_on:
+      auth:
+        condition: service_healthy
+      api:
+        condition: service_started
+    ports:
+      - "8081:8080"
+    restart: on-failure:3
+
+  web:
+    build:
+      context: ./frontend
+      dockerfile: web-admin/Dockerfile
+      args:
+        BUILD_CONFIG: local   # usa environment.local.ts -> gateway en localhost:8081
+    depends_on:
+      gateway:
+        condition: service_started
+    ports:
+      - "8083:80"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: on-failure:3
+
+  landing:
+    build:
+      context: ./frontend
+      dockerfile: landing-page/Dockerfile
+      args:
+        VITE_WEB_ADMIN_URL: http://localhost:8083
+    ports:
+      - "8082:80"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: on-failure:3
 
 volumes:
   mongo_local_data:
   postgres_local_data:
+  redis_local_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,10 @@
+# Aplica a los builds con context=./frontend (web-admin y landing-page).
+# El web-admin/.dockerignore no aplica con ese context — este sí.
+**/node_modules
+**/dist
+**/dist-desktop
+**/.angular
+**/.env
+**/*.log
+**/e2e/results
+web-admin_backup.tar.gz

--- a/frontend/landing-page/src/components/ui/AppButton.vue
+++ b/frontend/landing-page/src/components/ui/AppButton.vue
@@ -39,7 +39,7 @@ const sizeClass: Record<Size, string> = {
   <component
     :is="href ? 'a' : 'button'"
     :href="href"
-    :disabled="!href && disabled"
+    :disabled="!href && disabled ? true : undefined"
     :aria-disabled="href && disabled ? true : undefined"
     class="btn"
     :class="[variantClass[variant], sizeClass[size], { 'btn-wide': wide, 'btn-disabled': disabled }]"

--- a/frontend/landing-page/src/composables/useReveal.ts
+++ b/frontend/landing-page/src/composables/useReveal.ts
@@ -1,0 +1,35 @@
+import { onMounted, onBeforeUnmount } from 'vue'
+
+/**
+ * Activa las animaciones de entrada: observa todos los elementos con
+ * .reveal / .reveal-left / .reveal-right y les agrega .active cuando
+ * entran al viewport. Sin esto, el CSS los deja en opacity:0 para siempre.
+ */
+export function useReveal() {
+  let observer: IntersectionObserver | null = null
+
+  onMounted(() => {
+    const targets = document.querySelectorAll<HTMLElement>('.reveal, .reveal-left, .reveal-right')
+
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (reduced || !('IntersectionObserver' in window)) {
+      targets.forEach(el => el.classList.add('active'))
+      return
+    }
+
+    observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('active')
+            observer?.unobserve(entry.target)
+          }
+        }
+      },
+      { threshold: 0.15, rootMargin: '0px 0px -40px 0px' },
+    )
+    targets.forEach(el => observer!.observe(el))
+  })
+
+  onBeforeUnmount(() => observer?.disconnect())
+}

--- a/frontend/landing-page/src/views/home/HomeView.vue
+++ b/frontend/landing-page/src/views/home/HomeView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { useReveal } from '@/composables/useReveal'
 import Nvar from '@/components/layout/Nvar.vue'
 import HeroSection from '@/views/home/sections/Hero.vue'
 import ProductShowcaseSection from '@/views/home/sections/ProductShowcase.vue'
@@ -12,22 +12,7 @@ import FAQSection from '@/views/home/sections/FAQ.vue'
 import CtaSection from '@/views/home/sections/Cta.vue'
 import FooterLayout from '@/components/layout/Footer.vue'
 
-onMounted(() => {
-  const observer = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          entry.target.classList.add('active')
-        }
-      })
-    },
-    { threshold: 0.12, rootMargin: '0px 0px -40px 0px' },
-  )
-
-  document.querySelectorAll('.reveal, .reveal-left, .reveal-right').forEach((el) => {
-    observer.observe(el)
-  })
-})
+useReveal()
 </script>
 
 <template>

--- a/frontend/web-admin/angular.json
+++ b/frontend/web-admin/angular.json
@@ -55,6 +55,27 @@
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true
+            },
+            "local": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.local.ts"
+                }
+              ],
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kB",
+                  "maximumError": "1MB"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "4kB",
+                  "maximumError": "8kB"
+                }
+              ],
+              "outputHashing": "all"
             }
           },
           "defaultConfiguration": "production"

--- a/frontend/web-admin/src/app/auth/verify/verify.page.ts
+++ b/frontend/web-admin/src/app/auth/verify/verify.page.ts
@@ -59,7 +59,14 @@ import { TcLogoComponent } from '../../shared/ui/logo/tc-logo.component';
 
         <p class="text-center text-xs text-base-content/30 mt-6">
           ¿No recibiste el código?
-          <button class="text-primary hover:underline" type="button">Reenviar</button>
+          <button
+            class="text-primary hover:underline disabled:opacity-40 disabled:cursor-not-allowed"
+            type="button"
+            [disabled]="resendCooldown() > 0"
+            (click)="resend()"
+          >
+            @if (resendCooldown() > 0) { Reenviar ({{ resendCooldown() }}s) } @else { Reenviar }
+          </button>
         </p>
       </div>
     </div>
@@ -74,6 +81,8 @@ export class VerifyPage {
   loading = signal(false);
   error = signal('');
   email = signal(this.route.snapshot.queryParamMap.get('email') ?? '');
+  resendCooldown = signal(0);
+  private cooldownTimer: ReturnType<typeof setInterval> | null = null;
 
   form = this.fb.nonNullable.group({
     code: ['', [Validators.required, Validators.minLength(4)]],
@@ -99,5 +108,23 @@ export class VerifyPage {
         this.loading.set(false);
       },
     });
+  }
+
+  resend(): void {
+    if (this.resendCooldown() > 0) return;
+    this.auth.resendVerification(this.email()).subscribe({
+      next: () => this.startCooldown(60),
+      error: () => this.startCooldown(30),
+    });
+  }
+
+  private startCooldown(seconds: number): void {
+    this.resendCooldown.set(seconds);
+    if (this.cooldownTimer) clearInterval(this.cooldownTimer);
+    this.cooldownTimer = setInterval(() => {
+      const v = this.resendCooldown() - 1;
+      this.resendCooldown.set(v);
+      if (v <= 0 && this.cooldownTimer) { clearInterval(this.cooldownTimer); this.cooldownTimer = null; }
+    }, 1000);
   }
 }

--- a/frontend/web-admin/src/app/core/auth.service.ts
+++ b/frontend/web-admin/src/app/core/auth.service.ts
@@ -39,6 +39,10 @@ export class AuthService {
     );
   }
 
+  resendVerification(email: string): Observable<void> {
+    return this.http.post<void>(`${this.api}/auth/resend-verification`, { email });
+  }
+
   logout(): void {
     [LS_TOKEN, LS_USER, LS_TENANT].forEach(k => localStorage.removeItem(k));
     this.currentUser.set(null);

--- a/frontend/web-admin/src/app/core/settings.service.ts
+++ b/frontend/web-admin/src/app/core/settings.service.ts
@@ -4,14 +4,17 @@ import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 
 export interface BusinessProfile {
-  id: string;
-  name: string;
+  businessName: string;
+  rnc: string | null;
+  businessAddress: string;
+  phone: string | null;
+  email: string | null;
 }
 
 @Injectable({ providedIn: 'root' })
 export class SettingsService {
   private http = inject(HttpClient);
-  private api = `${environment.gatewayUrl}/gateway`;
+  private api = `${environment.gatewayUrl}/gateway/api/v1`;
 
   getProfile(): Observable<BusinessProfile | null> {
     return this.http.get<BusinessProfile | null>(`${this.api}/settings/profile`);

--- a/frontend/web-admin/src/app/delivery/delivery.page.ts
+++ b/frontend/web-admin/src/app/delivery/delivery.page.ts
@@ -1,17 +1,169 @@
-import { Component, ChangeDetectionStrategy, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import {
+  Component, ChangeDetectionStrategy, inject, signal, CUSTOM_ELEMENTS_SCHEMA,
+} from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { DeliveriesService } from '../portal/deliveries/services/deliveries.service';
+import { DeliveryPendiente, direccionCompleta } from '../portal/deliveries/models/delivery.model';
+import { SpinnerComponent } from '../shared/ui/spinner/spinner.component';
+import { BadgeComponent } from '../shared/ui/badge/badge.component';
+import { ModalComponent } from '../shared/ui/modal/modal.component';
+import { BtnComponent } from '../shared/ui/btn/btn.component';
+import { ToastService } from '../shared/ui/toast/toast.service';
+import { RdCurrencyPipe } from '../shared/ui/pipes/rd-currency.pipe';
+
+const PM_CASH = 1;
 
 @Component({
   selector: 'app-delivery-page',
   changeDetection: ChangeDetectionStrategy.OnPush,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  imports: [DatePipe, SpinnerComponent, BadgeComponent, ModalComponent, BtnComponent, RdCurrencyPipe],
   template: `
-    <div class="min-h-screen bg-base-200 flex items-center justify-center">
-      <div class="text-center space-y-3">
-        <iconify-icon icon="lucide:bike" class="text-5xl text-base-content/20"></iconify-icon>
-        <h1 class="text-2xl font-black text-base-content">Vista Repartidor</h1>
-        <p class="text-base-content/40 text-sm">En construcción</p>
+    <div class="min-h-screen bg-base-200 p-4 space-y-4 max-w-2xl mx-auto">
+      <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-black text-base-content tracking-tight">
+          <iconify-icon icon="lucide:bike" class="text-primary align-middle mr-1"></iconify-icon>
+          Entregas
+        </h1>
+        <button appBtn variant="ghost" size="sm" (click)="load()">
+          <iconify-icon icon="lucide:refresh-cw"></iconify-icon>
+          Actualizar
+        </button>
       </div>
+
+      @if (loading()) {
+        <div class="flex justify-center py-16"><app-spinner size="lg" /></div>
+      } @else if (pendientes().length === 0) {
+        <div class="flex flex-col items-center py-20 gap-3">
+          <iconify-icon icon="lucide:coffee" class="text-6xl text-base-content/20"></iconify-icon>
+          <p class="text-base-content/40">No hay entregas pendientes</p>
+        </div>
+      } @else {
+        @for (d of pendientes(); track d.id) {
+          <div class="tc-card p-4 space-y-3">
+            <div class="flex items-start justify-between gap-2">
+              <div>
+                <p class="font-black">{{ d.customerName || 'Sin nombre' }}</p>
+                <p class="text-xs text-base-content/40 font-mono">{{ d.receiptNumber }} · {{ d.createdAt | date:'HH:mm' }}</p>
+              </div>
+              <app-badge [variant]="d.status === 'InTransit' ? 'warning' : 'ghost'">{{ d.status }}</app-badge>
+            </div>
+
+            <div class="text-sm space-y-1">
+              <p><iconify-icon icon="lucide:map-pin" class="text-primary align-middle mr-1"></iconify-icon>{{ direccion(d) }}</p>
+              @if (d.addressReference) {
+                <p class="text-base-content/50 text-xs pl-5">{{ d.addressReference }}</p>
+              }
+              @if (d.phone) {
+                <a class="text-primary font-bold" href="tel:{{ d.phone }}">
+                  <iconify-icon icon="lucide:phone" class="align-middle mr-1"></iconify-icon>{{ d.phone }}
+                </a>
+              }
+            </div>
+
+            <div class="flex items-center justify-between pt-1">
+              <p class="text-lg font-black text-primary">{{ d.totalAmount | rdCurrency }}</p>
+              @if (d.status === 'InTransit') {
+                <button appBtn size="sm" (click)="onStartComplete(d, completeModal)">
+                  <iconify-icon icon="lucide:check"></iconify-icon>
+                  Entregada
+                </button>
+              } @else {
+                <button appBtn size="sm" [loading]="working() === d.id" (click)="onAccept(d)">
+                  <iconify-icon icon="lucide:navigation"></iconify-icon>
+                  Aceptar
+                </button>
+              }
+            </div>
+          </div>
+        }
+      }
     </div>
+
+    <!-- Completar entrega -->
+    <app-modal #completeModal title="Confirmar entrega">
+      @if (seleccionada(); as d) {
+        <div class="space-y-4">
+          <p class="text-sm text-base-content/60">
+            Cobra <span class="font-black text-base-content">{{ d.totalAmount | rdCurrency }}</span>
+            y pide al cliente su código de confirmación.
+          </p>
+          <div class="form-control">
+            <label class="label pb-1" for="dlv-code">
+              <span class="text-xs font-bold uppercase tracking-wider">Código de confirmación *</span>
+            </label>
+            <input
+              id="dlv-code" type="text" class="tc-input text-center text-xl font-black tracking-[0.3em]"
+              [value]="codigo()" (input)="codigo.set($any($event.target).value)" maxlength="8" autocomplete="off"
+            />
+          </div>
+          @if (error(); as err) {
+            <p class="text-sm text-secondary font-bold">{{ err }}</p>
+          }
+          <div modalActions>
+            <button type="button" class="tc-btn tc-btn-ghost" (click)="completeModal.close()">Cancelar</button>
+            <button appBtn [loading]="working() === d.id" [disabled]="!codigo().trim()" (click)="onComplete(d, completeModal)">
+              Confirmar entrega
+            </button>
+          </div>
+        </div>
+      }
+    </app-modal>
   `,
 })
-export class DeliveryPage {}
+export class DeliveryPage {
+  private svc = inject(DeliveriesService);
+  private toast = inject(ToastService);
+
+  loading = signal(true);
+  working = signal<string | null>(null);
+  pendientes = signal<DeliveryPendiente[]>([]);
+  seleccionada = signal<DeliveryPendiente | null>(null);
+  codigo = signal('');
+  error = signal<string | null>(null);
+
+  constructor() { this.load(); }
+
+  load(): void {
+    this.loading.set(true);
+    this.svc.getPendientes().subscribe({
+      next: (items) => { this.pendientes.set(items); this.loading.set(false); },
+      error: () => { this.toast.error('Error cargando entregas'); this.loading.set(false); },
+    });
+  }
+
+  direccion(d: DeliveryPendiente): string { return direccionCompleta(d); }
+
+  onAccept(d: DeliveryPendiente): void {
+    this.working.set(d.id);
+    this.svc.aceptar(d.id).subscribe({
+      next: () => { this.working.set(null); this.toast.success('Entrega aceptada'); this.load(); },
+      error: (e) => { this.working.set(null); this.toast.error(e?.error?.detail ?? 'No se pudo aceptar'); },
+    });
+  }
+
+  onStartComplete(d: DeliveryPendiente, modal: ModalComponent): void {
+    this.seleccionada.set(d);
+    this.codigo.set('');
+    this.error.set(null);
+    modal.open();
+  }
+
+  onComplete(d: DeliveryPendiente, modal: ModalComponent): void {
+    this.working.set(d.id);
+    this.error.set(null);
+    const payments = [{ paymentMethodId: PM_CASH, amount: d.totalAmount, reference: null, customerId: null }];
+    this.svc.completar(d.id, payments, this.codigo().trim()).subscribe({
+      next: () => {
+        this.working.set(null);
+        modal.close();
+        this.toast.success('Entrega completada');
+        this.load();
+      },
+      error: (e) => {
+        this.working.set(null);
+        this.error.set(e?.error?.detail ?? 'Código incorrecto o error al completar.');
+      },
+    });
+  }
+}

--- a/frontend/web-admin/src/app/portal/clientes/pages/lista-clientes.page.ts
+++ b/frontend/web-admin/src/app/portal/clientes/pages/lista-clientes.page.ts
@@ -85,20 +85,9 @@ import { Cliente } from '../models/cliente.model';
             </tbody>
           </app-table>
 
-          @if (totalPages() > 1) {
-            <div class="flex items-center justify-between px-4 py-3 border-t border-base-300">
-              <p class="text-sm text-base-content/50">{{ totalCount() }} cliente{{ totalCount() !== 1 ? 's' : '' }}</p>
-              <div class="join">
-                <button appBtn size="sm" class="join-item" [disabled]="page() === 1" (click)="changePage(page() - 1)">
-                  <iconify-icon icon="lucide:chevron-left"></iconify-icon>
-                </button>
-                <span class="join-item tc-btn tc-btn-sm tc-btn-ghost pointer-events-none">{{ page() }} / {{ totalPages() }}</span>
-                <button appBtn size="sm" class="join-item" [disabled]="page() === totalPages()" (click)="changePage(page() + 1)">
-                  <iconify-icon icon="lucide:chevron-right"></iconify-icon>
-                </button>
-              </div>
-            </div>
-          }
+          <div class="flex items-center px-4 py-3 border-t border-base-300">
+            <p class="text-sm text-base-content/50">{{ totalCount() }} cliente{{ totalCount() !== 1 ? 's' : '' }}</p>
+          </div>
         }
       </app-card>
     </div>
@@ -149,8 +138,6 @@ export class ListaClientesPage {
   saving = signal(false);
   clientes = signal<Cliente[]>([]);
   totalCount = signal(0);
-  totalPages = signal(0);
-  page = signal(1);
 
   clienteForm = this.fb.nonNullable.group({
     fullName: ['', [Validators.required, Validators.minLength(2)]],
@@ -163,18 +150,15 @@ export class ListaClientesPage {
 
   loadClientes(): void {
     this.loading.set(true);
-    this.svc.getClientes(this.page(), 20).subscribe({
-      next: (res: any) => {
-        this.clientes.set(res.items);
-        this.totalCount.set(res.totalCount);
-        this.totalPages.set(res.totalPages);
+    this.svc.getClientes().subscribe({
+      next: (res) => {
+        this.clientes.set(res);
+        this.totalCount.set(res.length);
         this.loading.set(false);
       },
       error: () => { this.toast.error('Error cargando clientes'); this.loading.set(false); },
     });
   }
-
-  changePage(p: number): void { this.page.set(p); this.loadClientes(); }
 
   onCreateCliente(modal: ModalComponent): void {
     if (this.clienteForm.invalid) return;

--- a/frontend/web-admin/src/app/portal/clientes/services/clientes.service.ts
+++ b/frontend/web-admin/src/app/portal/clientes/services/clientes.service.ts
@@ -1,17 +1,17 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../../environments/environment';
-import { Cliente, ClienteEstadoCuenta, PagedClientes } from '../models/cliente.model';
+import { Cliente, ClienteEstadoCuenta } from '../models/cliente.model';
 
 @Injectable({ providedIn: 'root' })
 export class ClientesService {
   private http = inject(HttpClient);
   private api = `${environment.gatewayUrl}/gateway/api/v1/customers`;
 
-  getClientes(page = 1, pageSize = 20): Observable<PagedClientes> {
-    const params = new HttpParams().set('page', page).set('pageSize', pageSize);
-    return this.http.get<PagedClientes>(this.api, { params });
+  // La API devuelve la lista completa con balance (no es paginada)
+  getClientes(): Observable<Cliente[]> {
+    return this.http.get<Cliente[]>(this.api);
   }
 
   getCliente(id: string): Observable<Cliente> {

--- a/frontend/web-admin/src/app/portal/configuracion/pages/configuracion.page.ts
+++ b/frontend/web-admin/src/app/portal/configuracion/pages/configuracion.page.ts
@@ -139,7 +139,9 @@ export class ConfiguracionPage implements OnInit {
     email: ['', Validators.email],
   });
 
-  ngOnInit(): void { this.loadProfile(); }
+  constructor() { this.loadProfile(); }
+
+  ngOnInit(): void { /* implemented via constructor */ }
 
   loadProfile(): void {
     this.loading.set(true);

--- a/frontend/web-admin/src/app/portal/dashboard/pages/dashboard.page.ts
+++ b/frontend/web-admin/src/app/portal/dashboard/pages/dashboard.page.ts
@@ -1,13 +1,33 @@
-import { Component, ChangeDetectionStrategy, inject, computed, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, computed, signal, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { AuthService } from '../../../core/auth.service';
 import { CardComponent } from '../../../shared/ui/card/card.component';
+import { SpinnerComponent } from '../../../shared/ui/spinner/spinner.component';
+import { environment } from '../../../../environments/environment';
 
 interface QuickLink {
   label: string;
   route: string;
   icon: string;
   description: string;
+}
+
+interface SalesReport {
+  total_revenue: number;
+  transaction_count: number;
+}
+
+interface CustomersReport {
+  total_customers: number;
+  with_debt: number;
+  total_debt: number;
+}
+
+interface ProductsPage {
+  totalCount: number;
 }
 
 const QUICK_LINKS: QuickLink[] = [
@@ -19,11 +39,15 @@ const QUICK_LINKS: QuickLink[] = [
   { label: 'Reportes', route: '/portal/reportes', icon: 'lucide:bar-chart-2', description: 'Analítica' },
 ];
 
+function formatCurrency(value: number): string {
+  return 'RD$ ' + value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
 @Component({
   selector: 'app-dashboard-page',
   changeDetection: ChangeDetectionStrategy.OnPush,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
-  imports: [RouterLink, CardComponent],
+  imports: [RouterLink, CardComponent, SpinnerComponent],
   template: `
     <div class="space-y-6">
       <!-- Welcome -->
@@ -60,20 +84,38 @@ const QUICK_LINKS: QuickLink[] = [
         }
       </div>
 
-      <!-- Placeholder stats -->
+      <!-- Stats -->
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        @for (stat of stats; track stat.label) {
-          <app-card [compact]="true">
-            <div class="flex items-start justify-between">
-              <div>
-                <p class="text-base-content/50 text-[10px] uppercase tracking-widest font-black">{{ stat.label }}</p>
-                <p class="text-2xl font-black text-base-content mt-1 italic tracking-tight">{{ stat.value }}</p>
+        @if (loading()) {
+          @for (stat of statsMeta; track stat.label) {
+            <app-card [compact]="true">
+              <div class="flex items-start justify-between">
+                <div>
+                  <p class="text-base-content/50 text-[10px] uppercase tracking-widest font-black">{{ stat.label }}</p>
+                  <div class="mt-2">
+                    <app-spinner size="sm" />
+                  </div>
+                </div>
+                <div class="w-8 h-8 bg-base-200 rounded flex items-center justify-center shrink-0">
+                  <iconify-icon [attr.icon]="stat.icon" class="text-xl text-base-content/30"></iconify-icon>
+                </div>
               </div>
-              <div class="w-8 h-8 bg-base-200 rounded flex items-center justify-center shrink-0">
-                <iconify-icon [attr.icon]="stat.icon" class="text-xl text-base-content/30"></iconify-icon>
+            </app-card>
+          }
+        } @else {
+          @for (stat of stats(); track stat.label) {
+            <app-card [compact]="true">
+              <div class="flex items-start justify-between">
+                <div>
+                  <p class="text-base-content/50 text-[10px] uppercase tracking-widest font-black">{{ stat.label }}</p>
+                  <p class="text-2xl font-black text-base-content mt-1 italic tracking-tight">{{ stat.value }}</p>
+                </div>
+                <div class="w-8 h-8 bg-base-200 rounded flex items-center justify-center shrink-0">
+                  <iconify-icon [attr.icon]="stat.icon" class="text-xl text-base-content/30"></iconify-icon>
+                </div>
               </div>
-            </div>
-          </app-card>
+            </app-card>
+          }
         }
       </div>
     </div>
@@ -81,17 +123,61 @@ const QUICK_LINKS: QuickLink[] = [
 })
 export class DashboardPage {
   private auth = inject(AuthService);
+  private http = inject(HttpClient);
+
   quickLinks = QUICK_LINKS;
+  loading = signal(true);
+  error = signal(false);
+
+  readonly statsMeta = [
+    { label: 'Ventas hoy',        icon: 'lucide:shopping-cart' },
+    { label: 'Ingresos hoy',      icon: 'lucide:trending-up' },
+    { label: 'Productos',         icon: 'lucide:package' },
+    { label: 'Fiados pendientes', icon: 'lucide:clipboard-list' },
+  ];
+
+  stats = signal([
+    { label: 'Ventas hoy',        value: '—', icon: 'lucide:shopping-cart' },
+    { label: 'Ingresos hoy',      value: '—', icon: 'lucide:trending-up' },
+    { label: 'Productos',         value: '—', icon: 'lucide:package' },
+    { label: 'Fiados pendientes', value: '—', icon: 'lucide:clipboard-list' },
+  ]);
 
   _name = computed(() => {
     const u = this.auth.currentUser();
     return u?.firstName ?? u?.email?.split('@')[0] ?? 'usuario';
   });
 
-  stats = [
-    { label: 'Ventas hoy',        value: '—', icon: 'lucide:shopping-cart' },
-    { label: 'Productos',         value: '—', icon: 'lucide:package' },
-    { label: 'Clientes activos',  value: '—', icon: 'lucide:users' },
-    { label: 'Fiados pendientes', value: '—', icon: 'lucide:clipboard-list' },
-  ];
+  constructor() { this.loadStats(); }
+
+  private loadStats(): void {
+    const tenantId = localStorage.getItem('tc_tenant') ?? '';
+    const today = new Date().toISOString().slice(0, 10);
+    const api = `${environment.gatewayUrl}/gateway/api/v1`;
+
+    const salesParams = new HttpParams()
+      .set('tenant_id', tenantId)
+      .set('from', today)
+      .set('to', today);
+
+    const customersParams = new HttpParams()
+      .set('tenant_id', tenantId);
+
+    const productsParams = new HttpParams()
+      .set('pageSize', '1');
+
+    forkJoin({
+      sales: this.http.get<SalesReport>(`${api}/reports/sales`, { params: salesParams }).pipe(catchError(() => of(null))),
+      customers: this.http.get<CustomersReport>(`${api}/reports/customers`, { params: customersParams }).pipe(catchError(() => of(null))),
+      products: this.http.get<ProductsPage>(`${api}/inventory/products`, { params: productsParams }).pipe(catchError(() => of(null))),
+    }).subscribe((results) => {
+      this.stats.set([
+        { label: 'Ventas hoy',        value: results.sales?.transaction_count != null ? String(results.sales.transaction_count) : '—', icon: 'lucide:shopping-cart' },
+        { label: 'Ingresos hoy',      value: results.sales?.total_revenue != null ? formatCurrency(results.sales.total_revenue) : '—', icon: 'lucide:trending-up' },
+        { label: 'Productos',         value: results.products?.totalCount != null ? String(results.products.totalCount) : '—', icon: 'lucide:package' },
+        { label: 'Fiados pendientes', value: results.customers?.with_debt != null ? String(results.customers.with_debt) : '—', icon: 'lucide:clipboard-list' },
+      ]);
+      this.loading.set(false);
+    });
+  }
 }

--- a/frontend/web-admin/src/app/portal/deliveries/models/delivery.model.ts
+++ b/frontend/web-admin/src/app/portal/deliveries/models/delivery.model.ts
@@ -1,9 +1,22 @@
+// Coincide con DeliveryOrderDto del Core API
 export interface DeliveryPendiente {
-  orderId: string;
+  id: string;
   saleId: string;
   receiptNumber: string;
-  customerName: string | null;
-  address: string;
-  createdAt: string;
+  totalAmount: number;
+  customerName: string;
+  phone: string;
+  addressProvince: string;
+  addressSector: string;
+  addressStreet: string;
+  addressHouseNumber: string | null;
+  addressReference: string;
   status: string;
+  createdAt: string;
+}
+
+export function direccionCompleta(d: DeliveryPendiente): string {
+  return [d.addressStreet, d.addressHouseNumber, d.addressSector, d.addressProvince]
+    .filter(Boolean)
+    .join(', ');
 }

--- a/frontend/web-admin/src/app/portal/deliveries/pages/lista-deliveries.page.ts
+++ b/frontend/web-admin/src/app/portal/deliveries/pages/lista-deliveries.page.ts
@@ -7,7 +7,7 @@ import { CardComponent } from '../../../shared/ui/card/card.component';
 import { TableComponent } from '../../../shared/ui/table/table.component';
 import { SpinnerComponent } from '../../../shared/ui/spinner/spinner.component';
 import { ToastService } from '../../../shared/ui/toast/toast.service';
-import { DeliveryPendiente } from '../models/delivery.model';
+import { DeliveryPendiente, direccionCompleta } from '../models/delivery.model';
 
 import { BtnComponent } from '../../../shared/ui/btn/btn.component';
 import { BadgeComponent } from '../../../shared/ui/badge/badge.component';
@@ -55,11 +55,11 @@ import { BadgeComponent } from '../../../shared/ui/badge/badge.component';
               </tr>
             </thead>
             <tbody>
-              @for (d of pendientes(); track d.orderId) {
+              @for (d of pendientes(); track d.id) {
                 <tr class="hover">
                   <td class="font-mono text-sm font-medium text-base-content">{{ d.receiptNumber }}</td>
-                  <td class="hidden sm:table-cell text-sm text-base-content/60">{{ d.customerName ?? 'Sin nombre' }}</td>
-                  <td class="text-sm text-base-content/60 max-w-48 truncate">{{ d.address }}</td>
+                  <td class="hidden sm:table-cell text-sm text-base-content/60">{{ d.customerName || 'Sin nombre' }}</td>
+                  <td class="text-sm text-base-content/60 max-w-48 truncate">{{ direccion(d) }}</td>
                   <td class="hidden md:table-cell text-sm text-base-content/60">{{ d.createdAt | date:'d MMM, HH:mm' }}</td>
                   <td>
                     <app-badge variant="warning">{{ d.status }}</app-badge>
@@ -90,4 +90,5 @@ export class ListaDeliveriesPage {
     });
   }
 
+  direccion(d: DeliveryPendiente): string { return direccionCompleta(d); }
 }

--- a/frontend/web-admin/src/app/portal/deliveries/services/deliveries.service.ts
+++ b/frontend/web-admin/src/app/portal/deliveries/services/deliveries.service.ts
@@ -12,4 +12,18 @@ export class DeliveriesService {
   getPendientes(): Observable<DeliveryPendiente[]> {
     return this.http.get<DeliveryPendiente[]>(`${this.api}/pending`);
   }
+
+  aceptar(id: string): Observable<{ status: string }> {
+    return this.http.post<{ status: string }>(`${this.api}/${id}/accept`, {});
+  }
+
+  completar(
+    id: string,
+    payments: { paymentMethodId: number; amount: number; reference?: string | null; customerId?: string | null }[],
+    confirmationCode: string,
+  ): Observable<{ status: string }> {
+    return this.http.post<{ status: string }>(`${this.api}/${id}/complete`, {
+      payments, confirmationCode, driverLatitude: null, driverLongitude: null,
+    });
+  }
 }

--- a/frontend/web-admin/src/app/portal/empleados/pages/lista-empleados.page.ts
+++ b/frontend/web-admin/src/app/portal/empleados/pages/lista-empleados.page.ts
@@ -58,6 +58,7 @@ const ROLES_DISPONIBLES = [
                 <th>Correo</th>
                 <th>Rol</th>
                 <th>Estado</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -76,6 +77,16 @@ const ROLES_DISPONIBLES = [
                     <app-badge [variant]="e.isActive ? 'success' : 'ghost'" size="xs">
                       {{ e.isActive ? 'Activo' : 'Inactivo' }}
                     </app-badge>
+                  </td>
+                  <td class="text-right">
+                    <button
+                      class="tc-btn tc-btn-ghost tc-btn-sm"
+                      (click)="onToggle(e)"
+                      [attr.aria-label]="e.isActive ? 'Desactivar' : 'Activar'"
+                    >
+                      <iconify-icon [icon]="e.isActive ? 'lucide:user-x' : 'lucide:user-check'"></iconify-icon>
+                      {{ e.isActive ? 'Desactivar' : 'Activar' }}
+                    </button>
                   </td>
                 </tr>
               }
@@ -180,6 +191,16 @@ export class ListaEmpleadosPage {
         this.saving.set(false);
       },
       error: () => { this.toast.error('Error al crear empleado'); this.saving.set(false); },
+    });
+  }
+
+  onToggle(e: Empleado): void {
+    this.svc.toggleEmpleado(e.id, !e.isActive).subscribe({
+      next: () => {
+        this.toast.success(e.isActive ? 'Empleado desactivado' : 'Empleado activado');
+        this.loadEmpleados();
+      },
+      error: () => this.toast.error('No se pudo cambiar el estado'),
     });
   }
 

--- a/frontend/web-admin/src/app/portal/empleados/services/empleados.service.ts
+++ b/frontend/web-admin/src/app/portal/empleados/services/empleados.service.ts
@@ -23,7 +23,13 @@ export class EmpleadosService {
     return this.http.post<Empleado>(this.api, data);
   }
 
-  updateEmpleado(id: string, data: Partial<{ role: string; isActive: boolean }>): Observable<Empleado> {
-    return this.http.patch<Empleado>(`${this.api}/${id}`, data);
+  // PUT = edición de datos (rol, nombre); lo maneja updateEmployee en el auth service
+  updateEmpleado(id: string, data: Partial<{ role: string; firstName: string; lastName: string }>): Observable<Empleado> {
+    return this.http.put<Empleado>(`${this.api}/${id}`, data);
+  }
+
+  // PATCH = activar/desactivar; el auth service espera { active }
+  toggleEmpleado(id: string, active: boolean): Observable<Empleado> {
+    return this.http.patch<Empleado>(`${this.api}/${id}`, { active });
   }
 }

--- a/frontend/web-admin/src/app/portal/inventario/pages/detalle-producto.page.ts
+++ b/frontend/web-admin/src/app/portal/inventario/pages/detalle-producto.page.ts
@@ -2,7 +2,6 @@ import {
   Component, ChangeDetectionStrategy, inject, signal, CUSTOM_ELEMENTS_SCHEMA,
 } from '@angular/core';
 import { RouterLink, ActivatedRoute } from '@angular/router';
-import { DatePipe } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { InventarioService } from '../services/inventario.service';
 import { CardComponent } from '../../../shared/ui/card/card.component';
@@ -24,7 +23,7 @@ import {
   selector: 'app-detalle-producto',
   changeDetection: ChangeDetectionStrategy.OnPush,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
-  imports: [RouterLink, ReactiveFormsModule, DatePipe, CardComponent, TableComponent, SpinnerComponent, BadgeComponent, ModalComponent, BtnComponent, RdCurrencyPipe, RdItbisPipe],
+  imports: [RouterLink, ReactiveFormsModule, CardComponent, TableComponent, SpinnerComponent, BadgeComponent, ModalComponent, BtnComponent, RdCurrencyPipe, RdItbisPipe],
   template: `
     <div class="space-y-5">
 

--- a/frontend/web-admin/src/app/portal/reportes/models/reporte.model.ts
+++ b/frontend/web-admin/src/app/portal/reportes/models/reporte.model.ts
@@ -1,0 +1,39 @@
+// Respuestas del reports-service (Rust) — llegan en snake_case
+export interface TopProducto {
+  product_name: string;
+  units_sold: number;
+  revenue: number;
+}
+
+export interface ReporteVentas {
+  tenant_id: string;
+  period_from: string;
+  period_to: string;
+  total_revenue: number;
+  transaction_count: number;
+  average_ticket: number;
+  top_products: TopProducto[];
+  generated_at: string;
+}
+
+export interface AlertaStock {
+  product_id: string;
+  product_name: string;
+  category_name: string | null;
+  stock_quantity: number;
+  sale_price: number;
+}
+
+export interface ReporteInventario {
+  tenant_id: string;
+  low_stock: AlertaStock[];
+  generated_at: string;
+}
+
+export interface ReporteClientes {
+  tenant_id: string;
+  total_customers: number;
+  with_debt: number;
+  total_debt: number;
+  generated_at: string;
+}

--- a/frontend/web-admin/src/app/portal/reportes/pages/lista-reportes.page.ts
+++ b/frontend/web-admin/src/app/portal/reportes/pages/lista-reportes.page.ts
@@ -1,113 +1,170 @@
 import {
-  Component, ChangeDetectionStrategy, CUSTOM_ELEMENTS_SCHEMA,
+  Component, ChangeDetectionStrategy, inject, signal, CUSTOM_ELEMENTS_SCHEMA,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { CardComponent } from '../../../shared/ui/card/card.component';
+import { SpinnerComponent } from '../../../shared/ui/spinner/spinner.component';
+import { RdCurrencyPipe } from '../../../shared/ui/pipes/rd-currency.pipe';
+import { ToastService } from '../../../shared/ui/toast/toast.service';
+import { ReportesService } from '../services/reportes.service';
+import { ReporteVentas, ReporteInventario, ReporteClientes } from '../models/reporte.model';
 
-interface ReporteAcceso {
-  label: string;
-  description: string;
-  icon: string;
-  route: string;
-  available: boolean;
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
 }
-
-const REPORTES: ReporteAcceso[] = [
-  {
-    label: 'Ventas del día',
-    description: 'Resumen de ventas, pagos y caja del día',
-    icon: 'lucide:shopping-cart',
-    route: '/portal/ventas',
-    available: true,
-  },
-  {
-    label: 'Inventario',
-    description: 'Stock actual, productos activos e inactivos',
-    icon: 'lucide:package',
-    route: '/portal/inventario',
-    available: true,
-  },
-  {
-    label: 'Clientes con fiado',
-    description: 'Clientes con balance pendiente de pago',
-    icon: 'lucide:clipboard-list',
-    route: '/portal/clientes',
-    available: true,
-  },
-  {
-    label: 'Movimientos de caja',
-    description: 'Depósitos y gastos por fondo monetario',
-    icon: 'lucide:wallet',
-    route: '/portal/cajas',
-    available: true,
-  },
-  {
-    label: 'Análisis de ventas',
-    description: 'Tendencias, productos más vendidos, métricas avanzadas',
-    icon: 'lucide:bar-chart-2',
-    route: '',
-    available: false,
-  },
-  {
-    label: 'Rentabilidad',
-    description: 'Margen de ganancia por producto y categoría',
-    icon: 'lucide:trending-up',
-    route: '',
-    available: false,
-  },
-];
-
-import { BadgeComponent } from '../../../shared/ui/badge/badge.component';
 
 @Component({
   selector: 'app-lista-reportes',
   changeDetection: ChangeDetectionStrategy.OnPush,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
-  imports: [RouterLink, BadgeComponent],
+  imports: [RouterLink, CardComponent, SpinnerComponent, RdCurrencyPipe],
   template: `
     <div class="space-y-5">
 
-      <!-- Header -->
-      <div>
-        <h2 class="text-2xl font-black text-base-content tracking-tight">Reportes</h2>
-        <p class="text-sm text-base-content/50 mt-1">Accede a la información clave de tu negocio</p>
+      <div class="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 class="text-2xl font-black text-base-content tracking-tight">Reportes</h2>
+          <p class="text-sm text-base-content/50 mt-1">Ventas, inventario y fiados del negocio</p>
+        </div>
+        <div class="flex items-end gap-2">
+          <div class="form-control">
+            <label class="label pb-1" for="rep-from"><span class="text-xs font-bold uppercase tracking-wider">Desde</span></label>
+            <input id="rep-from" type="date" class="tc-input" [value]="from()" (change)="from.set($any($event.target).value)" />
+          </div>
+          <div class="form-control">
+            <label class="label pb-1" for="rep-to"><span class="text-xs font-bold uppercase tracking-wider">Hasta</span></label>
+            <input id="rep-to" type="date" class="tc-input" [value]="to()" (change)="to.set($any($event.target).value)" />
+          </div>
+          <button class="tc-btn tc-btn-primary" (click)="loadAll()">
+            <iconify-icon icon="lucide:refresh-cw"></iconify-icon>
+            Actualizar
+          </button>
+        </div>
       </div>
 
-      <!-- Grid -->
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        @for (r of reportes; track r.label) {
-          @if (r.available) {
-            <a
-              [routerLink]="r.route"
-              class="tc-card block p-5 hover:border-primary/40 hover:bg-primary/5 transition-colors group"
-            >
-              <div class="w-10 h-10 bg-primary/10 flex items-center justify-center rounded-lg mb-3">
-                <iconify-icon [attr.icon]="r.icon" class="text-primary text-xl"></iconify-icon>
-              </div>
-              <p class="font-bold text-base-content">{{ r.label }}</p>
-              <p class="text-[11px] text-base-content/50 mt-1.5 uppercase font-bold tracking-wider leading-relaxed">
-                {{ r.description }}
-              </p>
-            </a>
-          } @else {
-            <div class="tc-card p-5 opacity-50 cursor-not-allowed">
-              <div class="w-10 h-10 bg-base-200 flex items-center justify-center rounded-lg mb-3">
-                <iconify-icon [attr.icon]="r.icon" class="text-base-content/30 text-xl"></iconify-icon>
-              </div>
-              <div class="flex items-center gap-2">
-                <p class="font-bold text-base-content">{{ r.label }}</p>
-                <app-badge variant="ghost">Pronto</app-badge>
-              </div>
-              <p class="text-[11px] text-base-content/40 mt-1.5 uppercase font-bold tracking-wider leading-relaxed">
-                {{ r.description }}
-              </p>
+      @if (loading()) {
+        <div class="flex justify-center py-16"><app-spinner size="lg" /></div>
+      } @else {
+
+        <!-- Resumen de ventas -->
+        @if (ventas(); as v) {
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div class="tc-card p-5">
+              <p class="text-xs text-base-content/40 uppercase tracking-widest font-black">Ingresos del período</p>
+              <p class="text-3xl font-black text-primary mt-1">{{ v.total_revenue | rdCurrency }}</p>
             </div>
-          }
+            <div class="tc-card p-5">
+              <p class="text-xs text-base-content/40 uppercase tracking-widest font-black">Transacciones</p>
+              <p class="text-3xl font-black mt-1">{{ v.transaction_count }}</p>
+            </div>
+            <div class="tc-card p-5">
+              <p class="text-xs text-base-content/40 uppercase tracking-widest font-black">Ticket promedio</p>
+              <p class="text-3xl font-black mt-1">{{ v.average_ticket | rdCurrency }}</p>
+            </div>
+          </div>
+
+          <app-card>
+            <h3 class="font-black uppercase tracking-tight mb-3">Productos más vendidos</h3>
+            @if (v.top_products.length === 0) {
+              <p class="text-sm text-base-content/40 py-6 text-center">Sin ventas en el período seleccionado</p>
+            } @else {
+              <div class="space-y-2">
+                @for (p of v.top_products; track p.product_name; let i = $index) {
+                  <div class="flex items-center gap-3">
+                    <span class="w-6 text-center font-black text-base-content/30">{{ i + 1 }}</span>
+                    <div class="flex-1">
+                      <p class="text-sm font-bold">{{ p.product_name }}</p>
+                      <p class="text-xs text-base-content/40">{{ p.units_sold }} unidades</p>
+                    </div>
+                    <p class="font-black">{{ p.revenue | rdCurrency }}</p>
+                  </div>
+                }
+              </div>
+            }
+          </app-card>
+        } @else {
+          <div class="tc-card p-6 text-center text-sm text-base-content/40">
+            No se pudo cargar el reporte de ventas. Intenta actualizar.
+          </div>
         }
-      </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+          <!-- Fiados -->
+          @if (clientes(); as c) {
+            <app-card>
+              <div class="flex items-center justify-between mb-3">
+                <h3 class="font-black uppercase tracking-tight">Fiados</h3>
+                <a routerLink="/portal/clientes" class="text-xs text-primary font-bold uppercase">Ver clientes</a>
+              </div>
+              <div class="grid grid-cols-3 gap-3 text-center">
+                <div><p class="text-2xl font-black">{{ c.total_customers }}</p><p class="text-xs text-base-content/40 uppercase">Clientes</p></div>
+                <div><p class="text-2xl font-black">{{ c.with_debt }}</p><p class="text-xs text-base-content/40 uppercase">Con deuda</p></div>
+                <div><p class="text-2xl font-black text-secondary">{{ c.total_debt | rdCurrency }}</p><p class="text-xs text-base-content/40 uppercase">Deuda total</p></div>
+              </div>
+            </app-card>
+          }
+
+          <!-- Stock bajo -->
+          @if (inventario(); as inv) {
+            <app-card>
+              <div class="flex items-center justify-between mb-3">
+                <h3 class="font-black uppercase tracking-tight">Alertas de stock</h3>
+                <a routerLink="/portal/inventario" class="text-xs text-primary font-bold uppercase">Ver inventario</a>
+              </div>
+              @if (inv.low_stock.length === 0) {
+                <p class="text-sm text-base-content/40 py-6 text-center">Todo el inventario está en niveles saludables</p>
+              } @else {
+                <div class="space-y-2 max-h-64 overflow-y-auto">
+                  @for (a of inv.low_stock; track a.product_id) {
+                    <div class="flex items-center justify-between gap-2">
+                      <div class="min-w-0">
+                        <p class="text-sm font-bold truncate">{{ a.product_name }}</p>
+                        @if (a.category_name) {
+                          <p class="text-xs text-base-content/40">{{ a.category_name }}</p>
+                        }
+                      </div>
+                      <span class="tc-badge tc-badge-error shrink-0">{{ a.stock_quantity }} restantes</span>
+                    </div>
+                  }
+                </div>
+              }
+            </app-card>
+          }
+        </div>
+      }
     </div>
   `,
 })
 export class ListaReportesPage {
-  readonly reportes = REPORTES;
+  private svc = inject(ReportesService);
+  private toast = inject(ToastService);
+
+  loading = signal(true);
+  ventas = signal<ReporteVentas | null>(null);
+  inventario = signal<ReporteInventario | null>(null);
+  clientes = signal<ReporteClientes | null>(null);
+
+  from = signal(isoDate(new Date(Date.now() - 29 * 86_400_000)));
+  to = signal(isoDate(new Date()));
+
+  constructor() { this.loadAll(); }
+
+  loadAll(): void {
+    this.loading.set(true);
+    let pending = 3;
+    const done = () => { if (--pending === 0) this.loading.set(false); };
+
+    this.svc.getVentas(this.from(), this.to()).subscribe({
+      next: (v) => { this.ventas.set(v); done(); },
+      error: () => { this.toast.error('Error cargando reporte de ventas'); done(); },
+    });
+    this.svc.getInventario().subscribe({
+      next: (v) => { this.inventario.set(v); done(); },
+      error: () => { this.inventario.set(null); done(); },
+    });
+    this.svc.getClientes().subscribe({
+      next: (v) => { this.clientes.set(v); done(); },
+      error: () => { this.clientes.set(null); done(); },
+    });
+  }
 }

--- a/frontend/web-admin/src/app/portal/reportes/services/reportes.service.ts
+++ b/frontend/web-admin/src/app/portal/reportes/services/reportes.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { ReporteVentas, ReporteInventario, ReporteClientes } from '../models/reporte.model';
+
+@Injectable({ providedIn: 'root' })
+export class ReportesService {
+  private http = inject(HttpClient);
+  // El reports-service (Rust) responde en snake_case y exige tenant_id en query
+  private api = `${environment.gatewayUrl}/gateway/api/v1/reports`;
+
+  private params(from?: string, to?: string): HttpParams {
+    let p = new HttpParams().set('tenant_id', localStorage.getItem('tc_tenant') ?? '');
+    if (from) p = p.set('from', from);
+    if (to) p = p.set('to', to);
+    return p;
+  }
+
+  getVentas(from?: string, to?: string): Observable<ReporteVentas> {
+    return this.http.get<ReporteVentas>(`${this.api}/sales`, { params: this.params(from, to) });
+  }
+
+  getInventario(): Observable<ReporteInventario> {
+    return this.http.get<ReporteInventario>(`${this.api}/inventory-alerts`, { params: this.params() });
+  }
+
+  getClientes(): Observable<ReporteClientes> {
+    return this.http.get<ReporteClientes>(`${this.api}/customers`, { params: this.params() });
+  }
+}

--- a/frontend/web-admin/src/app/pos/models/pos.model.ts
+++ b/frontend/web-admin/src/app/pos/models/pos.model.ts
@@ -1,0 +1,92 @@
+export interface CatalogPresentation {
+  id: string;
+  productId: string;
+  displayName: string;
+  presentationType: number;
+  presentationTypeName: string;
+  sellMode: number;
+  sellModeName: string;
+  brand: string | null;
+  nominalCapacity: number | null;
+  measureUnit: number;
+  measureUnitName: string;
+  salePrice: number;
+  costPrice: number;
+  isActive: boolean;
+}
+
+export interface CatalogItem {
+  productId: string;
+  name: string;
+  categoryId: string;
+  categoryName: string;
+  itbisRate: number;
+  isActive: boolean;
+  presentations: CatalogPresentation[];
+}
+
+export interface Shift {
+  shiftId: string;
+  cashierName: string;
+  status: string;
+  openingCashAmount: number;
+  openedAt: string;
+  closedAt: string | null;
+  totalSalesCount: number;
+  totalSalesAmount: number;
+}
+
+export interface ShiftSummary {
+  shiftId: string;
+  openedAt: string;
+  initialCash: number;
+  totalCashSales: number;
+  totalAccountPayments: number;
+  totalExpenses: number;
+  expectedCash: number;
+}
+
+export interface CloseShiftResult {
+  shiftId: string;
+  totalSalesCount: number;
+  totalSalesAmount: number;
+  expectedCashAmount: number;
+  actualCashAmount: number;
+  cashDifference: number;
+  closedAt: string;
+}
+
+export interface CartLine {
+  product: CatalogItem;
+  presentation: CatalogPresentation;
+  quantity: number;
+}
+
+export const PAYMENT_METHODS = { CASH: 1, CREDIT: 2, CARD: 3, TRANSFER: 4 } as const;
+export type PaymentMode = 'cash' | 'card' | 'transfer' | 'credit';
+
+export interface CreateSalePayment {
+  paymentMethodId: number;
+  amount: number;
+  reference?: string | null;
+  customerId?: string | null;
+}
+
+export interface CreateSaleResult {
+  saleId: string;
+  receiptNumber: string;
+  ncfNumber: string | null;
+  subtotal: number;
+  totalItbis: number;
+  total: number;
+  totalPaid: number;
+  changeDue: number;
+  items: {
+    productId: string;
+    productName: string;
+    quantity: number;
+    unitPrice: number;
+    lineItbis: number;
+    lineTotal: number;
+  }[];
+}

--- a/frontend/web-admin/src/app/pos/pos.page.ts
+++ b/frontend/web-admin/src/app/pos/pos.page.ts
@@ -1,26 +1,539 @@
-import { Component, ChangeDetectionStrategy, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import {
+  Component, ChangeDetectionStrategy, inject, signal, computed, viewChild, CUSTOM_ELEMENTS_SCHEMA,
+} from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { PosService } from './services/pos.service';
+import { AuthService } from '../core/auth.service';
+import { ToastService } from '../shared/ui/toast/toast.service';
+import { SpinnerComponent } from '../shared/ui/spinner/spinner.component';
+import { ModalComponent } from '../shared/ui/modal/modal.component';
+import { BtnComponent } from '../shared/ui/btn/btn.component';
+import { BadgeComponent } from '../shared/ui/badge/badge.component';
+import { RdCurrencyPipe } from '../shared/ui/pipes/rd-currency.pipe';
+import {
+  CatalogItem, CatalogPresentation, CartLine, Shift, ShiftSummary,
+  CloseShiftResult, CreateSaleResult, PaymentMode, PAYMENT_METHODS,
+} from './models/pos.model';
 
 @Component({
   selector: 'app-pos-page',
   changeDetection: ChangeDetectionStrategy.OnPush,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  imports: [ReactiveFormsModule, SpinnerComponent, ModalComponent, BtnComponent, BadgeComponent, RdCurrencyPipe],
   template: `
-    <div class="min-h-[calc(100vh-var(--topbar-h)-48px)] bg-base-200 flex items-center justify-center p-6">
-      <div class="tc-card max-w-md w-full text-center p-12 shadow-2xl">
-        <div class="w-16 h-16 bg-primary/10 flex items-center justify-center rounded-full mx-auto mb-6">
-          <iconify-icon icon="lucide:scan-barcode" class="text-primary text-3xl"></iconify-icon>
-        </div>
-        <h1 class="text-3xl font-black text-base-content tracking-tighter italic uppercase leading-none mb-3">
-          Punto de Venta
-        </h1>
-        <p class="text-base-content/40 text-sm font-medium uppercase tracking-widest mb-8">
-          Próximamente disponible
-        </p>
-        <div class="tc-badge tc-badge-primary !rounded-md !py-2 px-4 italic font-bold">
-          En construcción activa
+    @if (loading()) {
+      <div class="min-h-[60vh] flex items-center justify-center"><app-spinner size="lg" /></div>
+
+    } @else if (!shift()) {
+      <!-- Sin turno abierto -->
+      <div class="min-h-[calc(100vh-var(--topbar-h)-48px)] flex items-center justify-center p-6">
+        <div class="tc-card max-w-md w-full text-center p-12 shadow-2xl">
+          <div class="w-16 h-16 bg-primary/10 flex items-center justify-center rounded-full mx-auto mb-6">
+            <iconify-icon icon="lucide:scan-barcode" class="text-primary text-3xl"></iconify-icon>
+          </div>
+          <h1 class="text-3xl font-black text-base-content tracking-tighter uppercase mb-3">Punto de venta</h1>
+          <p class="text-base-content/40 text-sm mb-8">Abre un turno de caja para empezar a vender</p>
+          <button appBtn (click)="openShiftModal.open()">
+            <iconify-icon icon="lucide:play" class="text-base"></iconify-icon>
+            Abrir turno
+          </button>
         </div>
       </div>
-    </div>
+
+    } @else {
+      <!-- POS activo -->
+      <div class="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-4 items-start">
+
+        <!-- Catálogo -->
+        <div class="space-y-3">
+          <div class="flex flex-wrap items-center gap-2">
+            <input
+              type="search" class="tc-input flex-1 min-w-48" placeholder="Buscar producto..."
+              [value]="search()" (input)="search.set($any($event.target).value)"
+            />
+            <button appBtn variant="ghost" size="sm" (click)="onOpenCloseModal()">
+              <iconify-icon icon="lucide:square" class="text-base"></iconify-icon>
+              Cerrar turno
+            </button>
+          </div>
+
+          <div class="flex flex-wrap gap-1.5">
+            <button
+              class="tc-btn tc-btn-sm" [class.tc-btn-primary]="categoria() === null"
+              (click)="categoria.set(null)"
+            >Todas</button>
+            @for (c of categorias(); track c.id) {
+              <button
+                class="tc-btn tc-btn-sm" [class.tc-btn-primary]="categoria() === c.id"
+                (click)="categoria.set(c.id)"
+              >{{ c.name }}</button>
+            }
+          </div>
+
+          @if (filteredItems().length === 0) {
+            <div class="flex flex-col items-center py-16 gap-3">
+              <iconify-icon icon="lucide:package-open" class="text-5xl text-base-content/20"></iconify-icon>
+              <p class="text-base-content/40 text-sm">No hay productos que coincidan</p>
+            </div>
+          } @else {
+            <div class="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 gap-3">
+              @for (item of filteredItems(); track item.productId) {
+                @for (p of item.presentations; track p.id) {
+                  <button
+                    type="button"
+                    class="tc-card text-left p-4 hover:border-primary/40 hover:bg-primary/5 transition-colors"
+                    (click)="addToCart(item, p)"
+                  >
+                    <p class="font-bold text-sm text-base-content leading-tight line-clamp-2">{{ p.displayName }}</p>
+                    <p class="text-[11px] text-base-content/40 uppercase tracking-wider mt-0.5">{{ item.categoryName }}</p>
+                    <p class="text-lg font-black text-primary mt-2">{{ p.salePrice | rdCurrency }}</p>
+                  </button>
+                }
+              }
+            </div>
+          }
+        </div>
+
+        <!-- Carrito -->
+        <div class="tc-card p-4 space-y-3 lg:sticky lg:top-4">
+          <div class="flex items-center justify-between">
+            <h2 class="font-black text-base-content uppercase tracking-tight">Carrito</h2>
+            <app-badge variant="ghost">Turno: {{ shift()!.cashierName }}</app-badge>
+          </div>
+
+          @if (cart().length === 0) {
+            <p class="text-sm text-base-content/40 text-center py-8">Toca un producto para agregarlo</p>
+          } @else {
+            <div class="space-y-2 max-h-[45vh] overflow-y-auto">
+              @for (line of cart(); track line.presentation.id) {
+                <div class="flex items-center gap-2 border-b border-base-300 pb-2">
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm font-bold truncate">{{ line.presentation.displayName }}</p>
+                    <p class="text-xs text-base-content/40">{{ line.presentation.salePrice | rdCurrency }} c/u</p>
+                  </div>
+                  <div class="join">
+                    <button class="tc-btn tc-btn-sm join-item" (click)="setQty(line, line.quantity - 1)" aria-label="Menos">−</button>
+                    <span class="join-item px-2 text-sm font-bold self-center w-8 text-center">{{ line.quantity }}</span>
+                    <button class="tc-btn tc-btn-sm join-item" (click)="setQty(line, line.quantity + 1)" aria-label="Más">+</button>
+                  </div>
+                  <p class="text-sm font-black w-20 text-right">{{ line.presentation.salePrice * line.quantity | rdCurrency }}</p>
+                  <button class="tc-btn tc-btn-ghost tc-btn-sm" (click)="removeLine(line)" aria-label="Quitar">
+                    <iconify-icon icon="lucide:x"></iconify-icon>
+                  </button>
+                </div>
+              }
+            </div>
+
+            <div class="space-y-1 pt-1 text-sm">
+              <div class="flex justify-between text-base-content/60">
+                <span>Subtotal</span><span>{{ subtotal() | rdCurrency }}</span>
+              </div>
+              <div class="flex justify-between text-base-content/60">
+                <span>ITBIS</span><span>{{ itbis() | rdCurrency }}</span>
+              </div>
+              <div class="flex justify-between text-lg font-black text-base-content">
+                <span>Total</span><span>{{ total() | rdCurrency }}</span>
+              </div>
+            </div>
+
+            <button appBtn class="w-full" (click)="onOpenCheckout()">
+              <iconify-icon icon="lucide:hand-coins" class="text-base"></iconify-icon>
+              Cobrar {{ total() | rdCurrency }}
+            </button>
+            <button class="tc-btn tc-btn-ghost tc-btn-sm w-full" (click)="clearCart()">Vaciar carrito</button>
+          }
+        </div>
+      </div>
+    }
+
+    <!-- Abrir turno -->
+    <app-modal #openShiftModal title="Abrir turno de caja">
+      <form [formGroup]="openForm" (ngSubmit)="onOpenShift(openShiftModal)" class="space-y-4">
+        <div class="form-control">
+          <label class="label pb-1" for="pos-cashier">
+            <span class="text-xs font-bold uppercase tracking-wider">Cajero *</span>
+          </label>
+          <input id="pos-cashier" type="text" class="tc-input" formControlName="cashierName" />
+        </div>
+        <div class="form-control">
+          <label class="label pb-1" for="pos-opening">
+            <span class="text-xs font-bold uppercase tracking-wider">Efectivo inicial (RD$) *</span>
+          </label>
+          <input id="pos-opening" type="number" min="0" step="0.01" class="tc-input" formControlName="openingCashAmount" />
+        </div>
+        <div modalActions>
+          <button type="button" class="tc-btn tc-btn-ghost" (click)="openShiftModal.close()">Cancelar</button>
+          <button appBtn type="submit" [loading]="saving()" [disabled]="openForm.invalid">Abrir turno</button>
+        </div>
+      </form>
+    </app-modal>
+
+    <!-- Cerrar turno -->
+    <app-modal #closeShiftModal title="Cerrar turno">
+      @if (summary(); as s) {
+        <div class="grid grid-cols-2 gap-2 text-sm mb-4">
+          <div class="tc-card p-3"><p class="text-xs text-base-content/40 uppercase">Inicial</p><p class="font-black">{{ s.initialCash | rdCurrency }}</p></div>
+          <div class="tc-card p-3"><p class="text-xs text-base-content/40 uppercase">Ventas efectivo</p><p class="font-black">{{ s.totalCashSales | rdCurrency }}</p></div>
+          <div class="tc-card p-3"><p class="text-xs text-base-content/40 uppercase">Abonos</p><p class="font-black">{{ s.totalAccountPayments | rdCurrency }}</p></div>
+          <div class="tc-card p-3"><p class="text-xs text-base-content/40 uppercase">Gastos</p><p class="font-black">{{ s.totalExpenses | rdCurrency }}</p></div>
+          <div class="tc-card p-3 col-span-2 bg-primary/5"><p class="text-xs text-base-content/40 uppercase">Efectivo esperado</p><p class="font-black text-primary text-lg">{{ s.expectedCash | rdCurrency }}</p></div>
+        </div>
+      }
+      <form [formGroup]="closeForm" (ngSubmit)="onCloseShift(closeShiftModal)" class="space-y-4">
+        <div class="form-control">
+          <label class="label pb-1" for="pos-actual">
+            <span class="text-xs font-bold uppercase tracking-wider">Efectivo contado (RD$) *</span>
+          </label>
+          <input id="pos-actual" type="number" min="0" step="0.01" class="tc-input" formControlName="actualCashAmount" />
+        </div>
+        <div class="form-control">
+          <label class="label pb-1" for="pos-notes">
+            <span class="text-xs font-bold uppercase tracking-wider">Notas</span>
+          </label>
+          <input id="pos-notes" type="text" class="tc-input" formControlName="notes" placeholder="Opcional" />
+        </div>
+        <div modalActions>
+          <button type="button" class="tc-btn tc-btn-ghost" (click)="closeShiftModal.close()">Cancelar</button>
+          <button appBtn type="submit" [loading]="saving()" [disabled]="closeForm.invalid">Cerrar turno</button>
+        </div>
+      </form>
+    </app-modal>
+
+    <!-- Cobro -->
+    <app-modal #checkoutModal title="Cobrar venta">
+      <div class="space-y-4">
+        <p class="text-3xl font-black text-primary text-center">{{ total() | rdCurrency }}</p>
+
+        <div class="grid grid-cols-4 gap-1.5">
+          @for (m of modes; track m.id) {
+            <button
+              type="button" class="tc-btn tc-btn-sm flex-col h-auto py-2"
+              [class.tc-btn-primary]="mode() === m.id"
+              (click)="mode.set(m.id)"
+            >
+              <iconify-icon [icon]="m.icon" class="text-lg"></iconify-icon>
+              <span class="text-[10px]">{{ m.label }}</span>
+            </button>
+          }
+        </div>
+
+        @if (mode() === 'cash') {
+          <div class="form-control">
+            <label class="label pb-1" for="pos-tendered">
+              <span class="text-xs font-bold uppercase tracking-wider">Recibido (RD$)</span>
+            </label>
+            <input
+              id="pos-tendered" type="number" min="0" step="0.01" class="tc-input text-lg font-bold"
+              [value]="tendered()" (input)="tendered.set(+$any($event.target).value || 0)"
+            />
+            @if (tendered() >= total()) {
+              <p class="text-sm mt-2 text-base-content/60">Devuelta: <span class="font-black text-base-content">{{ tendered() - total() | rdCurrency }}</span></p>
+            }
+          </div>
+        }
+
+        @if (mode() === 'credit') {
+          <div class="form-control">
+            <label class="label pb-1" for="pos-customer">
+              <span class="text-xs font-bold uppercase tracking-wider">Cliente (fiao) *</span>
+            </label>
+            <select id="pos-customer" class="tc-input" [value]="customerId() ?? ''" (change)="customerId.set($any($event.target).value || null)">
+              <option value="">— Selecciona un cliente —</option>
+              @for (c of customers(); track c.customerId) {
+                <option [value]="c.customerId">{{ c.fullName }} (debe {{ c.balance | rdCurrency }})</option>
+              }
+            </select>
+          </div>
+        }
+
+        @if (mode() === 'card' || mode() === 'transfer') {
+          <div class="form-control">
+            <label class="label pb-1" for="pos-ref">
+              <span class="text-xs font-bold uppercase tracking-wider">Referencia</span>
+            </label>
+            <input id="pos-ref" type="text" class="tc-input" [value]="reference()" (input)="reference.set($any($event.target).value)" placeholder="Núm. de aprobación / transferencia" />
+          </div>
+        }
+
+        @if (checkoutError(); as err) {
+          <p class="text-sm text-secondary font-bold">{{ err }}</p>
+        }
+
+        <div modalActions>
+          <button type="button" class="tc-btn tc-btn-ghost" (click)="checkoutModal.close()">Cancelar</button>
+          <button appBtn [loading]="saving()" (click)="onConfirmSale(checkoutModal, receiptModal)">Confirmar venta</button>
+        </div>
+      </div>
+    </app-modal>
+
+    <!-- Recibo -->
+    <app-modal #receiptModal title="Venta completada">
+      @if (lastSale(); as r) {
+        <div class="space-y-3">
+          <div class="text-center">
+            <iconify-icon icon="lucide:check-circle-2" class="text-5xl text-success"></iconify-icon>
+            <p class="font-black text-lg mt-1">Recibo {{ r.receiptNumber }}</p>
+            @if (r.ncfNumber) {
+              <p class="text-xs text-base-content/40 uppercase tracking-wider">NCF {{ r.ncfNumber }}</p>
+            }
+          </div>
+          <div class="space-y-1 text-sm border-t border-base-300 pt-2">
+            @for (it of r.items; track it.productId) {
+              <div class="flex justify-between">
+                <span class="text-base-content/60">{{ it.quantity }} × {{ it.productName }}</span>
+                <span class="font-bold">{{ it.lineTotal | rdCurrency }}</span>
+              </div>
+            }
+          </div>
+          <div class="border-t border-base-300 pt-2 text-sm space-y-1">
+            <div class="flex justify-between text-base-content/60"><span>Subtotal</span><span>{{ r.subtotal | rdCurrency }}</span></div>
+            <div class="flex justify-between text-base-content/60"><span>ITBIS</span><span>{{ r.totalItbis | rdCurrency }}</span></div>
+            <div class="flex justify-between font-black text-lg"><span>Total</span><span>{{ r.total | rdCurrency }}</span></div>
+            @if (r.changeDue > 0) {
+              <div class="flex justify-between text-primary font-black"><span>Devuelta</span><span>{{ r.changeDue | rdCurrency }}</span></div>
+            }
+          </div>
+          <div modalActions>
+            <button appBtn (click)="receiptModal.close()">Nueva venta</button>
+          </div>
+        </div>
+      }
+    </app-modal>
+
+    <!-- Resultado cierre -->
+    <app-modal #closeResultModal title="Turno cerrado">
+      @if (closeResult(); as r) {
+        <div class="space-y-2 text-sm">
+          <div class="flex justify-between"><span class="text-base-content/60">Ventas</span><span class="font-bold">{{ r.totalSalesCount }} ({{ r.totalSalesAmount | rdCurrency }})</span></div>
+          <div class="flex justify-between"><span class="text-base-content/60">Esperado</span><span class="font-bold">{{ r.expectedCashAmount | rdCurrency }}</span></div>
+          <div class="flex justify-between"><span class="text-base-content/60">Contado</span><span class="font-bold">{{ r.actualCashAmount | rdCurrency }}</span></div>
+          <div class="flex justify-between text-lg font-black" [class.text-secondary]="r.cashDifference < 0">
+            <span>Diferencia</span><span>{{ r.cashDifference | rdCurrency }}</span>
+          </div>
+          <div modalActions>
+            <button appBtn (click)="closeResultModal.close()">Entendido</button>
+          </div>
+        </div>
+      }
+    </app-modal>
   `,
 })
-export class PosPage {}
+export class PosPage {
+  private svc = inject(PosService);
+  private auth = inject(AuthService);
+  private toast = inject(ToastService);
+  private fb = inject(FormBuilder);
+
+  loading = signal(true);
+  saving = signal(false);
+  shift = signal<Shift | null>(null);
+  catalog = signal<CatalogItem[]>([]);
+  summary = signal<ShiftSummary | null>(null);
+  closeResult = signal<CloseShiftResult | null>(null);
+  lastSale = signal<CreateSaleResult | null>(null);
+
+  search = signal('');
+  categoria = signal<string | null>(null);
+  cart = signal<CartLine[]>([]);
+
+  mode = signal<PaymentMode>('cash');
+  tendered = signal(0);
+  reference = signal('');
+  customerId = signal<string | null>(null);
+  customers = signal<{ customerId: string; fullName: string; balance: number; creditLimit: number; isActive: boolean }[]>([]);
+  checkoutError = signal<string | null>(null);
+
+  modes: { id: PaymentMode; label: string; icon: string }[] = [
+    { id: 'cash', label: 'Efectivo', icon: 'lucide:banknote' },
+    { id: 'card', label: 'Tarjeta', icon: 'lucide:credit-card' },
+    { id: 'transfer', label: 'Transfer.', icon: 'lucide:smartphone' },
+    { id: 'credit', label: 'Fiao', icon: 'lucide:notebook-pen' },
+  ];
+
+  categorias = computed(() => {
+    const seen = new Map<string, string>();
+    for (const i of this.catalog()) seen.set(i.categoryId, i.categoryName);
+    return [...seen].map(([id, name]) => ({ id, name }));
+  });
+
+  filteredItems = computed(() => {
+    const q = this.search().trim().toLowerCase();
+    const cat = this.categoria();
+    return this.catalog()
+      .filter(i => i.isActive && (!cat || i.categoryId === cat))
+      .map(i => ({
+        ...i,
+        presentations: i.presentations.filter(p =>
+          p.isActive && (!q || p.displayName.toLowerCase().includes(q) || i.name.toLowerCase().includes(q))),
+      }))
+      .filter(i => i.presentations.length > 0);
+  });
+
+  subtotal = computed(() =>
+    this.cart().reduce((acc, l) => {
+      const line = l.presentation.salePrice * l.quantity;
+      return acc + line / (1 + l.product.itbisRate);
+    }, 0));
+  total = computed(() => this.cart().reduce((acc, l) => acc + l.presentation.salePrice * l.quantity, 0));
+  itbis = computed(() => this.total() - this.subtotal());
+
+  openForm = this.fb.nonNullable.group({
+    cashierName: ['', [Validators.required, Validators.minLength(2)]],
+    openingCashAmount: [0, [Validators.required, Validators.min(0)]],
+  });
+
+  closeForm = this.fb.nonNullable.group({
+    actualCashAmount: [0, [Validators.required, Validators.min(0)]],
+    notes: [''],
+  });
+
+  constructor() {
+    const u = this.auth.currentUser();
+    const name = [u?.firstName, u?.lastName].filter(Boolean).join(' ') || u?.email || '';
+    this.openForm.patchValue({ cashierName: name });
+    this.refresh();
+  }
+
+  refresh(): void {
+    this.loading.set(true);
+    this.svc.getCurrentShift().subscribe({
+      next: (s) => {
+        this.shift.set(s);
+        if (s) this.loadCatalog();
+        else this.loading.set(false);
+      },
+      error: () => { this.shift.set(null); this.loading.set(false); },
+    });
+  }
+
+  loadCatalog(): void {
+    this.svc.getCatalog().subscribe({
+      next: (items) => { this.catalog.set(items); this.loading.set(false); },
+      error: () => { this.toast.error('Error cargando el catálogo'); this.loading.set(false); },
+    });
+  }
+
+  addToCart(product: CatalogItem, presentation: CatalogPresentation): void {
+    this.cart.update(cart => {
+      const existing = cart.find(l => l.presentation.id === presentation.id);
+      if (existing) {
+        return cart.map(l => l.presentation.id === presentation.id ? { ...l, quantity: l.quantity + 1 } : l);
+      }
+      return [...cart, { product, presentation, quantity: 1 }];
+    });
+  }
+
+  setQty(line: CartLine, qty: number): void {
+    if (qty <= 0) { this.removeLine(line); return; }
+    this.cart.update(cart => cart.map(l => l.presentation.id === line.presentation.id ? { ...l, quantity: qty } : l));
+  }
+
+  removeLine(line: CartLine): void {
+    this.cart.update(cart => cart.filter(l => l.presentation.id !== line.presentation.id));
+  }
+
+  clearCart(): void { this.cart.set([]); }
+
+  onOpenShift(modal: ModalComponent): void {
+    if (this.openForm.invalid) return;
+    this.saving.set(true);
+    const v = this.openForm.getRawValue();
+    this.svc.openShift(v.openingCashAmount, v.cashierName).subscribe({
+      next: () => { this.saving.set(false); modal.close(); this.toast.success('Turno abierto'); this.refresh(); },
+      error: (e) => { this.saving.set(false); this.toast.error(e?.error?.detail ?? 'Error al abrir el turno'); },
+    });
+  }
+
+  private closeShiftModal = viewChild<ModalComponent>('closeShiftModal');
+  private checkoutModal = viewChild<ModalComponent>('checkoutModal');
+  private closeResultModal = viewChild<ModalComponent>('closeResultModal');
+
+  onOpenCloseModal(): void {
+    this.svc.getCurrentShiftSummary().subscribe({
+      next: (s) => {
+        this.summary.set(s);
+        this.closeForm.patchValue({ actualCashAmount: s.expectedCash, notes: '' });
+      },
+      error: () => this.summary.set(null),
+    });
+    this.closeShiftModal()?.open();
+  }
+
+  onCloseShift(modal: ModalComponent): void {
+    const shift = this.shift();
+    if (!shift || this.closeForm.invalid) return;
+    this.saving.set(true);
+    const v = this.closeForm.getRawValue();
+    this.svc.closeShift(shift.shiftId, v.actualCashAmount, v.notes || null).subscribe({
+      next: (r) => {
+        this.saving.set(false);
+        modal.close();
+        this.closeResult.set(r);
+        this.shift.set(null);
+        this.cart.set([]);
+        this.toast.success('Turno cerrado');
+        this.closeResultModal()?.open();
+      },
+      error: (e) => { this.saving.set(false); this.toast.error(e?.error?.detail ?? 'Error al cerrar el turno'); },
+    });
+  }
+
+  onOpenCheckout(): void {
+    this.checkoutError.set(null);
+    this.mode.set('cash');
+    this.tendered.set(this.total());
+    this.reference.set('');
+    this.customerId.set(null);
+    if (this.customers().length === 0) {
+      this.svc.getCustomers().subscribe({ next: (c) => this.customers.set(c.filter(x => x.isActive)), error: () => {} });
+    }
+    this.checkoutModal()?.open();
+  }
+
+  onConfirmSale(checkout: ModalComponent, receipt: ModalComponent): void {
+    const total = this.total();
+    const mode = this.mode();
+    this.checkoutError.set(null);
+
+    if (mode === 'credit' && !this.customerId()) {
+      this.checkoutError.set('Selecciona el cliente para la venta fiao.');
+      return;
+    }
+    if (mode === 'cash' && this.tendered() < total) {
+      this.checkoutError.set('El monto recibido es menor al total.');
+      return;
+    }
+
+    const methodId = mode === 'cash' ? PAYMENT_METHODS.CASH
+      : mode === 'card' ? PAYMENT_METHODS.CARD
+      : mode === 'transfer' ? PAYMENT_METHODS.TRANSFER
+      : PAYMENT_METHODS.CREDIT;
+
+    const items = this.cart().map(l => ({
+      productId: l.product.productId,
+      presentationId: l.presentation.id,
+      quantity: l.quantity,
+    }));
+    const payments = [{
+      paymentMethodId: methodId,
+      amount: mode === 'cash' ? this.tendered() : total,
+      reference: this.reference() || null,
+      customerId: mode === 'credit' ? this.customerId() : null,
+    }];
+
+    this.saving.set(true);
+    this.svc.createSale(items, payments, null, null).subscribe({
+      next: (r) => {
+        this.saving.set(false);
+        checkout.close();
+        this.lastSale.set(r);
+        this.cart.set([]);
+        receipt.open();
+      },
+      error: (e) => {
+        this.saving.set(false);
+        this.checkoutError.set(e?.error?.detail ?? 'No se pudo registrar la venta.');
+      },
+    });
+  }
+}

--- a/frontend/web-admin/src/app/pos/services/pos.service.ts
+++ b/frontend/web-admin/src/app/pos/services/pos.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import {
+  CatalogItem, Shift, ShiftSummary, CloseShiftResult,
+  CreateSalePayment, CreateSaleResult,
+} from '../models/pos.model';
+
+@Injectable({ providedIn: 'root' })
+export class PosService {
+  private http = inject(HttpClient);
+  private api = `${environment.gatewayUrl}/gateway/api/v1`;
+
+  getCatalog(): Observable<CatalogItem[]> {
+    return this.http.get<CatalogItem[]>(`${this.api}/inventory/catalog`);
+  }
+
+  getCurrentShift(): Observable<Shift | null> {
+    return this.http.get<Shift | null>(`${this.api}/sales/shifts/current`);
+  }
+
+  getCurrentShiftSummary(): Observable<ShiftSummary> {
+    return this.http.get<ShiftSummary>(`${this.api}/sales/shifts/current/summary`);
+  }
+
+  openShift(openingCashAmount: number, cashierName: string): Observable<{ shiftId: string }> {
+    return this.http.post<{ shiftId: string }>(`${this.api}/sales/shifts/open`, {
+      openingCashAmount, cashierName,
+    });
+  }
+
+  closeShift(shiftId: string, actualCashAmount: number, notes: string | null): Observable<CloseShiftResult> {
+    return this.http.post<CloseShiftResult>(`${this.api}/sales/shifts/${shiftId}/close`, {
+      actualCashAmount, notes,
+    });
+  }
+
+  // Clientes para ventas a crédito (fiao). La API devuelve la lista completa.
+  getCustomers(): Observable<{ customerId: string; fullName: string; balance: number; creditLimit: number; isActive: boolean }[]> {
+    return this.http.get<{ customerId: string; fullName: string; balance: number; creditLimit: number; isActive: boolean }[]>(
+      `${this.api}/customers`,
+    );
+  }
+
+  createSale(
+    items: { productId: string; presentationId: string; quantity: number }[],
+    payments: CreateSalePayment[],
+    notes: string | null,
+    buyerRnc: string | null,
+  ): Observable<CreateSaleResult> {
+    return this.http.post<CreateSaleResult>(`${this.api}/sales`, {
+      items, payments, notes, buyerRnc,
+    });
+  }
+}

--- a/frontend/web-admin/src/environments/environment.local.ts
+++ b/frontend/web-admin/src/environments/environment.local.ts
@@ -1,0 +1,5 @@
+// Build "local": app corriendo en Docker local, gateway expuesto en :8081
+export const environment = {
+  production: true,
+  gatewayUrl: 'http://localhost:8081',
+};

--- a/scripts/seed-test-accounts.ts
+++ b/scripts/seed-test-accounts.ts
@@ -3,206 +3,304 @@ import bcrypt from 'bcryptjs';
 import { randomUUID } from 'crypto';
 import { Client } from 'pg';
 
-const MONGODB_URI = 'mongodb://root:1234@localhost:27019/tu_colmado_auth?authSource=admin';
-const POSTGRES_URI = 'postgresql://postgres:1234@localhost:54329/TuColmadoDb';
+// Override via env vars to target any environment.
+const MONGODB_URI = process.env.MONGODB_URI
+  ?? 'mongodb://tucolmado:local1234@localhost:27017/tu_colmado_auth?authSource=admin';
+const POSTGRES_URI = process.env.POSTGRES_URI
+  ?? 'postgresql://postgres:1234@localhost:54329/TuColmadoDb';
 
-const tenantSchema = new mongoose.Schema({
-  _id: { type: String, required: true },
-  name: { type: String, required: true },
-  isActive: { type: Boolean, default: true },
-  subscriptionStatus: { type: String, enum: ['active', 'trialing', 'expired'], default: 'trialing' }
-}, { timestamps: true });
+// Fixed IDs — seed is fully idempotent (safe to re-run).
+const EXAMPLE_TENANT_ID = 'a1000000-0000-4000-8000-000000000001';
 
-const userSchema = new mongoose.Schema({
-  tenantId:  { type: String, required: true },
-  email:     { type: String, required: true, unique: true },
-  password:  { type: String, required: true },
-  firstName: { type: String, default: null },
-  lastName:  { type: String, default: null },
-  // Must match Role enum in auth service: owner | delivery | seller
-  role:      { type: String, enum: ['owner', 'delivery', 'seller'], required: true },
-  isActive:  { type: Boolean, default: true }
-}, { timestamps: true });
+// ─── Mongoose inline schemas (minimal — mirror the real auth service models) ──
 
-const Tenant = mongoose.models.Tenant || mongoose.model('Tenant', tenantSchema);
-const User   = mongoose.models.User   || mongoose.model('User',   userSchema);
+const TenantSchema = new mongoose.Schema(
+  {
+    _id:                { type: String, required: true },
+    name:               { type: String, required: true },
+    isActive:           { type: Boolean, default: true },
+    subscriptionStatus: { type: String, enum: ['active', 'trialing', 'expired'], default: 'active' },
+  },
+  { timestamps: true, _id: false },
+);
+
+const UserSchema = new mongoose.Schema(
+  {
+    tenantId:  { type: String, required: true },
+    email:     { type: String, required: true, lowercase: true, trim: true },
+    password:  { type: String, required: true },
+    firstName: { type: String, default: null },
+    lastName:  { type: String, default: null },
+    role:      { type: String, enum: ['owner', 'admin', 'cashier', 'seller', 'delivery'], required: true },
+    status:    { type: String, enum: ['PENDING_VERIFICATION', 'ACTIVE', 'SUSPENDED'], default: 'PENDING_VERIFICATION' },
+    verificationCode:       { type: String, default: null },
+    verificationCodeExpiry: { type: Date, default: null },
+  },
+  { timestamps: true },
+);
+
+const Tenant = mongoose.models['Tenant'] ?? mongoose.model('Tenant', TenantSchema);
+const User   = mongoose.models['User']   ?? mongoose.model('User',   UserSchema);
+
+// ─── Enum values that match the C# domain enums ───────────────────────────────
+// PresentationType: 1=BulkContainer, 2=PackagedUnit
+// SellMode:        1=ByUnit, 2=ByWeight
+// UnitOfMeasure:   1=Pound, 10=Unit, 20=Liter, 22=Bottle
+
+const BULK   = { presentationType: 1, sellMode: 2 }; // weighed goods
+const PACKED = { presentationType: 2, sellMode: 1 }; // closed packages
+
+const UNIT   = 10;
+const POUND  = 1;
+const LITER  = 20;
+const BOTTLE = 22;
+
+interface ProductDef {
+  name: string;
+  cat:  string;
+  cost: number;
+  sale: number;
+  itbis: number;
+  unit: number;
+  presentationType: number;
+  sellMode: number;
+  stock: number;
+}
+
+const PRODUCTS: ProductDef[] = [
+  // Alimentos y Abarrotes
+  { name: 'Arroz (libra)',           cat: 'Alimentos y Abarrotes', cost: 18,  sale: 22,  itbis: 0,    unit: POUND,  ...BULK,   stock: 200 },
+  { name: 'Habichuelas Rojas (lb)',  cat: 'Alimentos y Abarrotes', cost: 25,  sale: 30,  itbis: 0,    unit: POUND,  ...BULK,   stock: 100 },
+  { name: 'Aceite Vegetal 1L',       cat: 'Alimentos y Abarrotes', cost: 160, sale: 185, itbis: 0.18, unit: BOTTLE, ...PACKED, stock: 48  },
+  { name: 'Espaguetis 400g',         cat: 'Alimentos y Abarrotes', cost: 45,  sale: 55,  itbis: 0.18, unit: UNIT,   ...PACKED, stock: 60  },
+  { name: 'Sazón Completo (sobre)',  cat: 'Alimentos y Abarrotes', cost: 8,   sale: 12,  itbis: 0,    unit: UNIT,   ...PACKED, stock: 120 },
+  { name: 'Ajo (cabeza)',            cat: 'Alimentos y Abarrotes', cost: 20,  sale: 28,  itbis: 0,    unit: UNIT,   ...PACKED, stock: 80  },
+  { name: 'Sal Yodada 1Kg',          cat: 'Alimentos y Abarrotes', cost: 30,  sale: 40,  itbis: 0,    unit: UNIT,   ...PACKED, stock: 50  },
+  // Bebidas
+  { name: 'Agua Mineral 500ml',      cat: 'Bebidas',               cost: 18,  sale: 25,  itbis: 0.18, unit: BOTTLE, ...PACKED, stock: 144 },
+  { name: 'Refresco 2L',             cat: 'Bebidas',               cost: 100, sale: 130, itbis: 0.18, unit: BOTTLE, ...PACKED, stock: 36  },
+  { name: 'Jugo Tampico 473ml',      cat: 'Bebidas',               cost: 35,  sale: 45,  itbis: 0.18, unit: BOTTLE, ...PACKED, stock: 72  },
+  { name: 'Cerveza Presidente Lata', cat: 'Bebidas',               cost: 70,  sale: 90,  itbis: 0.18, unit: UNIT,   ...PACKED, stock: 48  },
+  // Lácteos y Huevos
+  { name: 'Leche Evaporada 370g',    cat: 'Lácteos y Huevos',      cost: 75,  sale: 95,  itbis: 0.18, unit: UNIT,   ...PACKED, stock: 48  },
+  { name: 'Huevo (unidad)',          cat: 'Lácteos y Huevos',      cost: 14,  sale: 18,  itbis: 0,    unit: UNIT,   ...PACKED, stock: 120 },
+  { name: 'Queso de Mano (libra)',   cat: 'Lácteos y Huevos',      cost: 180, sale: 220, itbis: 0,    unit: POUND,  ...BULK,   stock: 20  },
+  // Carnes y Embutidos
+  { name: 'Salami Induveca (libra)', cat: 'Carnes y Embutidos',    cost: 120, sale: 150, itbis: 0,    unit: POUND,  ...BULK,   stock: 30  },
+  { name: 'Longaniza (libra)',       cat: 'Carnes y Embutidos',    cost: 100, sale: 130, itbis: 0,    unit: POUND,  ...BULK,   stock: 25  },
+  // Limpieza y Hogar
+  { name: 'Cloro 1L',                cat: 'Limpieza y Hogar',      cost: 65,  sale: 85,  itbis: 0.18, unit: LITER,  ...PACKED, stock: 30  },
+  { name: 'Detergente en Polvo',     cat: 'Limpieza y Hogar',      cost: 40,  sale: 55,  itbis: 0.18, unit: UNIT,   ...PACKED, stock: 40  },
+  { name: 'Papel Higiénico x4',     cat: 'Limpieza y Hogar',      cost: 120, sale: 155, itbis: 0.18, unit: UNIT,   ...PACKED, stock: 24  },
+  // Higiene Personal
+  { name: 'Jabón de Baño',           cat: 'Higiene Personal',      cost: 35,  sale: 45,  itbis: 0.18, unit: UNIT,   ...PACKED, stock: 50  },
+  { name: 'Champú (sachet)',         cat: 'Higiene Personal',      cost: 10,  sale: 15,  itbis: 0.18, unit: UNIT,   ...PACKED, stock: 100 },
+  // Snacks y Dulces
+  { name: 'Galletas Soda',           cat: 'Snacks y Dulces',       cost: 25,  sale: 35,  itbis: 0.18, unit: UNIT,   ...PACKED, stock: 60  },
+  { name: 'Chicle (unidad)',         cat: 'Snacks y Dulces',       cost: 2,   sale: 3,   itbis: 0.18, unit: UNIT,   ...PACKED, stock: 200 },
+  { name: 'Frío Frío (sobre)',       cat: 'Snacks y Dulces',       cost: 10,  sale: 15,  itbis: 0,    unit: UNIT,   ...PACKED, stock: 150 },
+];
+
+const CATEGORIES = [
+  'Alimentos y Abarrotes',
+  'Bebidas',
+  'Lácteos y Huevos',
+  'Carnes y Embutidos',
+  'Limpieza y Hogar',
+  'Higiene Personal',
+  'Snacks y Dulces',
+  'Congelados',
+  'Otros',
+];
 
 async function seed() {
-  console.log('Iniciando script de seed de pruebas...');
+  console.log('Iniciando seed de Compañía Ejemplo...');
+  console.log('  MongoDB :', MONGODB_URI.replace(/:([^@]+)@/, ':***@'));
+  console.log('  Postgres:', POSTGRES_URI.replace(/:([^@]+)@/, ':***@'));
 
-  // ── MongoDB ───────────────────────────────────────────────────────────────
-  console.log('Conectando a MongoDB...');
+  // ── MongoDB ─────────────────────────────────────────────────────────────────
+  console.log('\n[MongoDB] Conectando...');
   await mongoose.connect(MONGODB_URI);
 
-  const tenantId     = randomUUID();
-  const passwordHash = await bcrypt.hash('Pruebas@1234', 10);
+  const ownerHash  = await bcrypt.hash('ArroZZ12hju.,', 10);
+  const staffHash  = await bcrypt.hash('Pruebas@1234', 10);
 
-  console.log('Creando Tenant en Mongo...');
+  console.log('[MongoDB] Upserting Tenant...');
   await Tenant.findOneAndUpdate(
-    { _id: tenantId },
-    { _id: tenantId, name: 'Colmado Pruebas SRL', isActive: true, subscriptionStatus: 'trialing' },
-    { upsert: true, new: true }
+    { _id: EXAMPLE_TENANT_ID },
+    {
+      _id: EXAMPLE_TENANT_ID,
+      name: 'Colmado Ejemplo SRL',
+      isActive: true,
+      subscriptionStatus: 'active',
+    },
+    { upsert: true, new: true },
   );
 
-  console.log('Creando Usuarios en Mongo...');
   const users = [
     {
-      tenantId,
-      email:     'owner@pruebassrl.com',
-      password:  passwordHash,
-      firstName: 'Dueño',
-      lastName:  'Pruebas',
-      role:      'owner',    // → accede a /portal (Owner | Admin guard)
-      isActive:  true
+      tenantId:  EXAMPLE_TENANT_ID,
+      email:     'borrome941@gmail.com',
+      password:  ownerHash,
+      firstName: 'Francisco',
+      lastName:  'Castro',
+      role:      'owner',
+      status:    'ACTIVE',
     },
     {
-      tenantId,
-      email:     'cajero@pruebassrl.com',
-      password:  passwordHash,
+      tenantId:  EXAMPLE_TENANT_ID,
+      email:     'cajero@ejemplo.com',
+      password:  staffHash,
       firstName: 'Cajero',
-      lastName:  'Uno',
-      role:      'seller',   // → accede a /pos (cajero/vendedor)
-      isActive:  true
+      lastName:  'Ejemplo',
+      role:      'seller',
+      status:    'ACTIVE',
     },
     {
-      tenantId,
-      email:     'delivery@pruebassrl.com',
-      password:  passwordHash,
+      tenantId:  EXAMPLE_TENANT_ID,
+      email:     'delivery@ejemplo.com',
+      password:  staffHash,
       firstName: 'Mensajero',
-      lastName:  'Pruebas',
-      role:      'delivery', // → rol de delivery
-      isActive:  true
+      lastName:  'Ejemplo',
+      role:      'delivery',
+      status:    'ACTIVE',
     },
   ];
 
+  console.log('[MongoDB] Upserting usuarios...');
   for (const u of users) {
     await User.findOneAndUpdate(
       { email: u.email },
       { $set: u },
-      { upsert: true, new: true }
+      { upsert: true, new: true },
     );
   }
 
-  console.log('Usuarios creados correctamente en Mongo.');
+  console.log('[MongoDB] Usuarios listos.');
   await mongoose.disconnect();
 
-  // ── PostgreSQL ────────────────────────────────────────────────────────────
-  console.log('Conectando a PostgreSQL...');
-  const client = new Client({ connectionString: POSTGRES_URI });
-  await client.connect();
+  // ── PostgreSQL ───────────────────────────────────────────────────────────────
+  console.log('\n[Postgres] Conectando...');
+  const pg = new Client({ connectionString: POSTGRES_URI });
+  await pg.connect();
 
-  console.log('Creando TenantProfile en Postgres...');
-  const tenantProfileId = randomUUID();
+  // TenantProfile
+  console.log('[Postgres] Upserting TenantProfile...');
+  await pg.query(
+    `INSERT INTO "System"."TenantProfiles"
+       ("Id", "TenantId", "BusinessName", "Rnc", "BusinessAddress", "Phone", "Email")
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     ON CONFLICT ("TenantId") DO UPDATE SET
+       "BusinessName"    = EXCLUDED."BusinessName",
+       "BusinessAddress" = EXCLUDED."BusinessAddress";`,
+    [
+      randomUUID(),
+      EXAMPLE_TENANT_ID,
+      'Colmado Ejemplo SRL',
+      '131111111',
+      'Av. Principal #1, Santo Domingo',
+      '809-555-0001',
+      'borrome941@gmail.com',
+    ],
+  );
 
-  const insertQuery = `
-    INSERT INTO "System"."TenantProfiles"
-      ("Id", "TenantId", "BusinessName", "Rnc", "BusinessAddress", "Phone", "Email")
-    VALUES ($1, $2, $3, $4, $5, $6, $7)
-    ON CONFLICT ("TenantId") DO NOTHING;
-  `;
-
-  await client.query(insertQuery, [
-    tenantProfileId,
-    tenantId,
-    'Colmado Pruebas SRL',
-    '131111111',
-    'Av. Principal #1, Santo Domingo',
-    '809-555-0000',
-    'contacto@pruebassrl.com'
-  ]);
-
-  console.log('TenantProfile creado en Postgres.');
-
-  console.log('Creando Categorías de Inventario en Postgres...');
-  const categoryNames = [
-    'Alimentos y Abarrotes',
-    'Bebidas',
-    'Lácteos y Huevos',
-    'Carnes y Embutidos',
-    'Limpieza y Hogar',
-    'Higiene Personal',
-    'Snacks y Dulces',
-    'Congelados',
-    'Otros',
-  ];
-
-  // Pre-generate IDs so we can reference them in products
+  // Categories
+  console.log('[Postgres] Upserting categorías...');
   const catMap: Record<string, string> = {};
-  for (const name of categoryNames) catMap[name] = randomUUID();
 
-  for (const [name, id] of Object.entries(catMap)) {
-    await client.query(
-      `INSERT INTO "Inventory"."Categories" ("Id", "TenantId", "Name", "IsActive")
-       VALUES ($1, $2, $3, true)
-       ON CONFLICT DO NOTHING;`,
-      [id, tenantId, name]
+  for (const name of CATEGORIES) {
+    // Deterministic ID based on tenant + name keeps reruns idempotent
+    // without needing a unique constraint on (TenantId, Name).
+    const existing = await pg.query<{ Id: string }>(
+      `SELECT "Id" FROM "Inventory"."Categories" WHERE "TenantId" = $1 AND "Name" = $2 LIMIT 1`,
+      [EXAMPLE_TENANT_ID, name],
     );
+
+    if (existing.rows.length > 0) {
+      catMap[name] = existing.rows[0].Id;
+    } else {
+      const id = randomUUID();
+      await pg.query(
+        `INSERT INTO "Inventory"."Categories" ("Id", "TenantId", "Name", "IsActive")
+         VALUES ($1, $2, $3, true)`,
+        [id, EXAMPLE_TENANT_ID, name],
+      );
+      catMap[name] = id;
+    }
   }
 
-  console.log(`${categoryNames.length} categorías creadas.`);
+  console.log(`[Postgres] ${CATEGORIES.length} categorías listas.`);
 
-  // ── Productos de prueba ───────────────────────────────────────────────────
-  console.log('Creando Productos de prueba en Postgres...');
+  // Products, Presentations, Stock
+  console.log('[Postgres] Verificando productos...');
+  const { rows: existingProducts } = await pg.query<{ cnt: string }>(
+    `SELECT COUNT(*)::text as cnt FROM "Inventory"."Products" WHERE "TenantId" = $1`,
+    [EXAMPLE_TENANT_ID],
+  );
 
-  // UnitType: 1=Unidad, 2=Libra, 3=Kilogramo, 4=Litro, 5=Galón, 6=Caja, 7=Docena
-  const products = [
-    // Alimentos y Abarrotes
-    { name: 'Arroz',                   cat: 'Alimentos y Abarrotes', cost: 18,  sale: 22,  itbis: 0,    unit: 2, stock: 200 },
-    { name: 'Habichuelas Rojas',       cat: 'Alimentos y Abarrotes', cost: 25,  sale: 30,  itbis: 0,    unit: 2, stock: 100 },
-    { name: 'Aceite Vegetal 1L',       cat: 'Alimentos y Abarrotes', cost: 160, sale: 185, itbis: 0.18, unit: 4, stock: 48  },
-    { name: 'Espaguetis 400g',         cat: 'Alimentos y Abarrotes', cost: 45,  sale: 55,  itbis: 0.18, unit: 1, stock: 60  },
-    { name: 'Sazón Completo (sobre)',  cat: 'Alimentos y Abarrotes', cost: 8,   sale: 12,  itbis: 0,    unit: 1, stock: 120 },
-    { name: 'Ajo (cabeza)',            cat: 'Alimentos y Abarrotes', cost: 20,  sale: 28,  itbis: 0,    unit: 1, stock: 80  },
-    { name: 'Sal Yodada 1Kg',         cat: 'Alimentos y Abarrotes', cost: 30,  sale: 40,  itbis: 0,    unit: 3, stock: 50  },
-    // Bebidas
-    { name: 'Agua Mineral 500ml',      cat: 'Bebidas',              cost: 18,  sale: 25,  itbis: 0.18, unit: 1, stock: 144 },
-    { name: 'Refresco 2L',             cat: 'Bebidas',              cost: 100, sale: 130, itbis: 0.18, unit: 1, stock: 36  },
-    { name: 'Jugo Tampico 473ml',      cat: 'Bebidas',              cost: 35,  sale: 45,  itbis: 0.18, unit: 1, stock: 72  },
-    { name: 'Cerveza Presidente Lata', cat: 'Bebidas',              cost: 70,  sale: 90,  itbis: 0.18, unit: 1, stock: 48  },
-    // Lácteos y Huevos
-    { name: 'Leche Evaporada 370g',    cat: 'Lácteos y Huevos',    cost: 75,  sale: 95,  itbis: 0.18, unit: 1, stock: 48  },
-    { name: 'Huevo (unidad)',          cat: 'Lácteos y Huevos',    cost: 14,  sale: 18,  itbis: 0,    unit: 1, stock: 120 },
-    { name: 'Queso de Mano',           cat: 'Lácteos y Huevos',    cost: 180, sale: 220, itbis: 0,    unit: 2, stock: 20  },
-    // Carnes y Embutidos
-    { name: 'Salami Induveca',         cat: 'Carnes y Embutidos',  cost: 120, sale: 150, itbis: 0,    unit: 2, stock: 30  },
-    { name: 'Longaniza',               cat: 'Carnes y Embutidos',  cost: 100, sale: 130, itbis: 0,    unit: 2, stock: 25  },
-    // Limpieza y Hogar
-    { name: 'Cloro 1L',               cat: 'Limpieza y Hogar',    cost: 65,  sale: 85,  itbis: 0.18, unit: 4, stock: 30  },
-    { name: 'Detergente en Polvo',     cat: 'Limpieza y Hogar',    cost: 40,  sale: 55,  itbis: 0.18, unit: 1, stock: 40  },
-    { name: 'Papel Higiénico x4',     cat: 'Limpieza y Hogar',    cost: 120, sale: 155, itbis: 0.18, unit: 1, stock: 24  },
-    // Higiene Personal
-    { name: 'Jabón de Baño',           cat: 'Higiene Personal',    cost: 35,  sale: 45,  itbis: 0.18, unit: 1, stock: 50  },
-    { name: 'Champú (sachet)',         cat: 'Higiene Personal',    cost: 10,  sale: 15,  itbis: 0.18, unit: 1, stock: 100 },
-    // Snacks y Dulces
-    { name: 'Galletas Soda',           cat: 'Snacks y Dulces',     cost: 25,  sale: 35,  itbis: 0.18, unit: 1, stock: 60  },
-    { name: 'Chicle (unidad)',         cat: 'Snacks y Dulces',     cost: 2,   sale: 3,   itbis: 0.18, unit: 1, stock: 200 },
-    { name: 'Frío Frío (sobre)',       cat: 'Snacks y Dulces',     cost: 10,  sale: 15,  itbis: 0,    unit: 1, stock: 150 },
-  ];
+  if (parseInt(existingProducts[0].cnt) > 0) {
+    console.log(`[Postgres] Ya existen ${existingProducts[0].cnt} productos — omitiendo.`);
+  } else {
+    const now = new Date().toISOString();
+    console.log(`[Postgres] Insertando ${PRODUCTS.length} productos + presentaciones + stock...`);
 
-  const now = new Date().toISOString();
-  for (const p of products) {
-    await client.query(
-      `INSERT INTO "Inventory"."Products"
-         ("Id", "TenantId", "Name", "CategoryId", "CostPrice", "SalePrice", "ItbisRate",
-          "UnitType", "IsActive", "CreatedAt", "UpdatedAt", "StockQuantity")
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, true, $9, $9, $10)
-       ON CONFLICT DO NOTHING;`,
-      [randomUUID(), tenantId, p.name, catMap[p.cat], p.cost, p.sale, p.itbis, p.unit, now, p.stock]
-    );
+    for (const p of PRODUCTS) {
+      const productId      = randomUUID();
+      const presentationId = randomUUID();
+
+      // Product
+      await pg.query(
+        `INSERT INTO "Inventory"."Products"
+           ("Id", "TenantId", "CategoryId", "Name", "ItbisRate", "IsActive", "CreatedAt", "UpdatedAt")
+         VALUES ($1, $2, $3, $4, $5, true, $6, $6)`,
+        [productId, EXAMPLE_TENANT_ID, catMap[p.cat], p.name, p.itbis, now],
+      );
+
+      // ProductPresentation (one default per product)
+      await pg.query(
+        `INSERT INTO "Inventory"."ProductPresentations"
+           ("Id", "TenantId", "ProductId", "DisplayName", "Brand",
+            "PresentationType", "SellMode", "MeasureUnit",
+            "CostPrice", "SalePrice", "NominalCapacity",
+            "IsActive", "CreatedAt", "UpdatedAt")
+         VALUES ($1, $2, $3, $4, '', $5, $6, $7, $8, $9, NULL, true, $10, $10)`,
+        [
+          presentationId,
+          EXAMPLE_TENANT_ID,
+          productId,
+          p.name,
+          p.presentationType,
+          p.sellMode,
+          p.unit,
+          p.cost,
+          p.sale,
+          now,
+        ],
+      );
+
+      // PackagedStock — only for PackagedUnit presentations (presentationType=2)
+      if (p.presentationType === 2) {
+        await pg.query(
+          `INSERT INTO "Inventory"."PackagedStock"
+             ("Id", "TenantId", "PresentationId", "Quantity", "LastUpdatedAt")
+           VALUES ($1, $2, $3, $4, $5)`,
+          [randomUUID(), EXAMPLE_TENANT_ID, presentationId, p.stock, now],
+        );
+      }
+    }
+
+    console.log(`[Postgres] ${PRODUCTS.length} productos creados.`);
   }
 
-  console.log(`${products.length} productos creados.`);
-  await client.end();
+  await pg.end();
 
-  // ── Summary ───────────────────────────────────────────────────────────────
+  // ── Summary ──────────────────────────────────────────────────────────────────
   console.log('\n✅ Seed completado.');
-  console.log('Tenant ID :', tenantId);
-  console.log('Password  : Pruebas@1234\n');
-  console.log('Cuentas de acceso:');
-  console.log('  owner@pruebassrl.com    (owner)    → /portal');
-  console.log('  cajero@pruebassrl.com   (seller)   → /pos');
-  console.log('  delivery@pruebassrl.com (delivery) → app móvil/delivery');
-  console.log(`\n9 categorías + ${products.length} productos de prueba creados.`);
+  console.log('Tenant ID :', EXAMPLE_TENANT_ID);
+  console.log('\nCuentas de acceso:');
+  console.log('  borrome941@gmail.com   pass: ArroZZ12hju.,   role: owner    → /portal');
+  console.log('  cajero@ejemplo.com     pass: Pruebas@1234    role: seller   → /pos');
+  console.log('  delivery@ejemplo.com   pass: Pruebas@1234    role: delivery → delivery');
 }
 
 seed().catch(err => {


### PR DESCRIPTION
## Resumen

Esta PR cierra todas las tareas pendientes del sprint de TuColmadoRD antes de publicar:

### Frontend web-admin — Módulos completados
- **POS**: reescritura completa (era un stub de 26 líneas) — apertura/cierre de turno, catálogo con búsqueda/filtro, carrito, cobro (efectivo/tarjeta/transferencia/fiado), recibo con NCF
- **Reportes**: nuevo módulo consumiendo el reports-service Rust — ingresos, top productos, fiados, alertas de stock bajo (antes era una lista de links estáticos)
- **Clientes**: corrección — API devuelve array plano, no paginado; se eliminó la paginación fantasma
- **Empleados**: `updateEmpleado` corregido a PUT; botón Activar/Desactivar funcional (PATCH `{active}`)
- **Deliveries + repartidor**: modelos reescritos al DTO real; aceptar/completar entrega con código de confirmación
- **settings.service**: base URL corregida `/gateway` → `/gateway/api/v1` (todos los endpoints daban 404)

### Frontend — UX completado
- **Dashboard**: 4 métricas reales con `forkJoin` — ventas/ingresos del día, total productos, fiados pendientes (antes era "—" en todo)
- **Verify page**: botón "Reenviar" ahora funciona con 60s de cooldown
- `AuthService.resendVerification()` conectado a `POST /auth/resend-verification`

### Landing — Fix crítico de CTAs
- `AppButton.vue`: rendería `disabled="false"` en `<a>` → DaisyUI aplicaba `pointer-events:none` → **todos los CTAs estaban muertos**. Fix: emitir `undefined` en vez de `false`.
- `useReveal` composable para animaciones de scroll
- `frontend/.dockerignore` correcto (contexto `./frontend`) — resolvía fallo de build donde `node_modules` del host se copiaban a la imagen

### Local stack
- `docker-compose.local.yml`: stack completo autocontenido — postgres, mongo, redis, mailhog, auth, notification, ecf, api, gateway, web (config `local`), landing

### DB — Correcciones críticas
- **NCF duplicado bajo concurrencia (CRÍTICO DGII)**: `CurrentSequence` ahora es concurrency token de EF; dos ventas simultáneas ya no pueden emitir el mismo NCF. La segunda falla con `DbUpdateConcurrencyException` y el endpoint reintenta automáticamente (hasta 3 veces, 409 si agota).
- **Índices por TenantId**: añadidos en `Sales`, `Customers`, `Products`, `FiscalSequences` — el query filter hacía seq scan en producción.
- Migración `AddFiscalSequenceConcurrencyAndTenantIndexes`: 4 `CreateIndex`, sin cambios destructivos.

### ECF — 3 blockers eliminados
- **BLOCKER-1**: `EcfGeneratorResponse.Xml` siempre era `""` — Python devuelve `{"xml":...}` (lowercase) y System.Text.Json es case-sensitive. Fix: `[JsonPropertyName("xml")]` + `PropertyNameCaseInsensitive = true`.
- **BLOCKER-2**: `ValorPagar` nunca se enviaba — campo requerido por la DGII para e31/e32.
- **BLOCKER-3**: `TotalITBIS1`, `ITBIS1="18"`, `DireccionEmisor` faltaban. Montos ahora en formato `"F2"` (`"1180.00"` no `"1180.0"`).
- ECF generator: proceso non-root, deps pinadas, 2 workers gunicorn, timeout 30s.
- Si el generador está caído → la venta completa sin TrackId (log Warning), no falla.
- Timeout HttpClient: 10s (era 100s default).

## Test plan

- [ ] `dotnet test TuColmadoRD.slnx` → 126/126 pasan ✅ (verificado localmente)
- [ ] `npx ng build --configuration=local` → 0 errores, 0 warnings ✅ (verificado localmente)
- [ ] `docker compose -f docker-compose.local.yml up --build` — stack completo en `localhost:8082/8083/8081`
- [ ] Login → Dashboard muestra métricas reales
- [ ] Registro → Verify page → botón Reenviar funciona con countdown
- [ ] POS: abrir turno → vender → cobrar (efectivo/tarjeta/fiado) → recibo con NCF → cerrar turno
- [ ] Reportes: ingresos, top productos, alertas stock, fiados
- [ ] Deliveries portal + vista repartidor
- [ ] Migración DB: `dotnet ef database update` sobre base limpia